### PR TITLE
fenced code blocks in config.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,8 @@ color:
 
 # Build settings
 markdown: kramdown
+kramdown:
+  input: GFM
 permalink: pretty
 
 # Jekyll Scholar


### PR DESCRIPTION
In the Moltres wiki, we were seeing code block line breaks ignored thus:

![image](https://cloud.githubusercontent.com/assets/393899/26423784/8e777e04-4094-11e7-83ba-8cfaa8746975.png)

This commit fixes the busted kramdown according to a suggestion in https://github.com/jekyll/jekyll/issues/3724, so now it looks like this: 


![image](https://cloud.githubusercontent.com/assets/393899/26423806/aa1f8c82-4094-11e7-810b-f9ad213d5a96.png)

