### PR TITLE
fixed forward slash

### DIFF
--- a/_data/research.yml
+++ b/_data/research.yml
@@ -10,6 +10,6 @@
 
 - name: Software
   pic: research/zen.png
-  url: /software
+  url: software
   description: 'ARFC has a strong focus on creating high quality scientific software. Discover it here.'
 


### PR DESCRIPTION
actually, your starting forward slash confuses the url builder... it tries to go to the url "/software" rather than arfc.github.io/software". can you guess why? This change fixes it