### PR TITLE
conf-abs moved to proper permalink

### DIFF
--- a/manual/guides/writing/conf-abs.md
+++ b/manual/guides/writing/conf-abs.md
@@ -2,34 +2,34 @@
 layout: manual
 title: Conference Abstract
 subtitle: "The most concrete of abstracts."
-permalink: /manual/guides/conf-abs/
+permalink: /manual/guides/writing/conf-abs/
 ---
 
 
-## Before Writing 
+## Before Writing
 
 - [ ] Decide where this will be submitted.
-- [ ] Is the conference appropriate for this topic? 
+- [ ] Is the conference appropriate for this topic?
 - [ ] Is the session appropriate for this topic?
 - [ ] Consider your audience.
-- [ ] Decide the scope. Do you have enough time before the conference to get 
+- [ ] Decide the scope. Do you have enough time before the conference to get
   the work done?
-- [ ] Confirm the speaker. If the abstract is accepted into the conference, who 
+- [ ] Confirm the speaker. If the abstract is accepted into the conference, who
   will give the talk?
-- [ ] Confirm travel. 
-- [ ] Confirm the authors. Give all authors ample opportunity to opt-out, read, 
+- [ ] Confirm travel.
+- [ ] Confirm the authors. Give all authors ample opportunity to opt-out, read,
   and revise the document before submission.
 
 
 ## Structure
 
-The conference abstract should describe a talk that you would give. 
+The conference abstract should describe a talk that you would give.
 
 
 ## Formatting
 
-Conferences vary in terms of formatting requirements. Follow the formatting 
-guide provided by the conference. ANS conference abstracts should use the 
+Conferences vary in terms of formatting requirements. Follow the formatting
+guide provided by the conference. ANS conference abstracts should use the
 ANS Transactions style.
 
 ## After Writing


### PR DESCRIPTION
When clicking the conference abstract link on the writing [webpage](http://arfc.github.io/manual/guides/writing/), it goes to a 404 [link](http://arfc.github.io/manual/guides/writing/conf-abs). I went through and found that the permalink in conf-abs.md was /manual/guides/conf-abs/ and not /manual/guides/writing/conf-abs/
