### PR TITLE
slightly clearer language about breaks.

### DIFF
--- a/manual/expectations.md
+++ b/manual/expectations.md
@@ -61,9 +61,14 @@ As your PI, it is my responsibility to do a number of things.
 
 - **Be present:** I expect you to be accessible during normal working hours. 
   Feel free to follow a schedule that works for you, work from home once in a 
-  while when you need to, and take breaks when you want to. But, by default, 
-  plan to come to the office during the daytime with regularity.  I won't track 
-  your hours, but I will worry if I haven't seen your face all week.
+  while when you need to, and take breaks when you need to. But, by default, 
+  plan to come to the office during the daytime with regularity.  
+  I won't track your hours, but I do want to know if you'll be 
+  out-of-communication, and I will worry if I haven't seen your face all week.
+  If you plan to take a vacation, please let me know in advance, particularly 
+  if we have meetings scheduled while you'll be away. Postdocs are considered 
+  staff, and should note that academic holidays are not always 
+  [staff holidays](http://humanresources.illinois.edu/employees/resources/info-about-your-employment/campus-holiday-schedule.html).
 - **Be productive** by writing papers and contributing to software toward the 
   missions of the group, the advancement of science in your field, building 
   your career, and expanding your expertise. 
@@ -133,8 +138,14 @@ Students who are my advisees have many responsibilities to themselves, to me, an
   Feel free to follow a schedule that works for you, work from home once in a 
   while when you need to, focus on coursework when that needs to take priority, 
   read for exams, and take breaks when you want to. But, by default, plan to 
-  come to the office during the daytime with regularity.  I won't track your 
-  hours, but I will worry if I haven't seen your face all week.
+  come to the office during the daytime with regularity.  
+  I won't track your hours, but I do want to know if you'll be 
+  out-of-communication, and I will worry if I haven't seen your face all week.
+  If you plan to take a vacation, please let me know in advance, particularly 
+  if we have meetings scheduled while you'll be away. Generally, graduate 
+  student research assistants are considered staff, and should note 
+  that academic holidays are not always 
+  [staff holidays](http://humanresources.illinois.edu/employees/resources/info-about-your-employment/campus-holiday-schedule.html).
 - **Participate:** actively in the university and the department, attending 
   colloquia, workshops, and other professional, technical, and departmental 
   events when they are relevant to your work and professional growth. Of 


### PR DESCRIPTION
## Summary of changes
It's recently become clear that the expectations doc doesn't quite capture my expectations about communicating vacations. While I'm never going to be interested in tracking student hours, I have always expected that students communicate times when they will be out of communication or when they plan to take a break from working on days that are not staff holidays. One expectation remains implicit rather than explicit: if we have a meeting scheduled on the group calendar, of course, it's simply common courtesy to let me know if you plan to miss it. 

## Types of changes
This change updates the expectations documentation on the website to make the vacation communication policy more clear. Specifically:

- [x] New feature (non-breaking change which adds functionality)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

## Associated Issues and PRs
n/a

## Associated Developers

- Dev: @achubbz 
- Dev: @gtw2 
- Dev: @gwenchee 
- Dev: @andrewryh 
- Dev: @jbae11 
- Dev: @robfairh 
- Dev: @smpark7 
- Dev: @kamuda1 
- Dev: @ZoeRichter 