### PR TITLE
Fix BC link in input_example.md

### DIFF
--- a/software/moltres/wiki/input_example.md
+++ b/software/moltres/wiki/input_example.md
@@ -360,7 +360,7 @@ can be optionally block restricted by setting `block = <subdomain_names>`.
 The `BCs` block is very similar to the `Kernels` block except the
 `boundary = <boundary_names>` parameter must be specified to indicate where the boundary
 conditions should be applied. The mathematical form of the BCs can be found on
-the [BCs wiki page](/software/moltres/wiki/kernels).
+the [BCs wiki page](/software/moltres/wiki/bcs).
 
 ```
 [Functions]


### PR DESCRIPTION
## Summary of changes
The MOLTRES input example documentation contained an incorrect link to the BCs page.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Associated Issues and PRs
<!--- Please note any issues or pull requests associated with this pull request -->

- Issue: #


## Associated Developers
<!--- Please mention any developers who should be alerted of this PR -->

- Dev: @
