### PR TITLE
Change the apostrophe on Kip's description to quotes

### DIFF
--- a/_data/alumni.yml
+++ b/_data/alumni.yml
@@ -409,7 +409,7 @@
   pic: /img/people/kleimenhagenk.jpg
   dates: 2019-2021
   role: Undergraduate Research Assistant
-  description: 'Kip was an undergraduate student in the NPRE department at UIUC, he's currently pursuing his master’s degree in nuclear engineering.'
+  description: "Kip was an undergraduate student in the NPRE department at UIUC, he's currently pursuing his master’s degree in nuclear engineering."
   social:
     - url: mailto:kiplk2@illinois.edu
       icon: envelope-o


### PR DESCRIPTION
## Summary of changes
<!--- In one or more sentences, describe the PR you are submitting -->
This PR is to Closes #239,  the issue Olek noticed where the alumni.yml file had a bug preventing his jekyll from rendering the site locally by changing the apostrophe's on Kip's description to quotations. Madicken, and Olek suspected this in his issue too, pointed out that the possessive in the description was ending the string prematurely. Quotes should be sufficient to work around this issue.

Something I'm still not sure of is how Nataly and I were able to render the site with `jekyll serve` on our machines. @yardasol is there some config you have such that a breaking change prevents the whole site from rendering? I haven't specifically configured jekyll on my machine, so I should be running on the defaults. This might be a good thing to create space for in the guides.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Associated Issues and PRs
<!--- Please note any issues or pull requests associated with this pull request -->

- Issue: #239 


## Associated Developers
<!--- Please mention any developers who should be alerted of this PR -->

- Dev: @yardasol 


## Checklist for Reviewers

Reviewers should use [this link](/manual/guides/pull_requests) to get to the 
Review Checklist before they begin their review.
