### PR TITLE
Fix broken cyder link on software page

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -6,7 +6,7 @@
   src: https://github.com/arfc/moltres
   url: https://arfc.github.io/software/moltres
   description: 'A Moltres is a MOOSE-application code designed for simulation of molten salt reactors.'
-  
+
 - name: cyclus
   pic: research/cyclus.gif
   network: github
@@ -15,13 +15,13 @@
   src: https://github.com/cyclus/cyclus
   url: https://fuelcycle.org
   description: 'A C++ nuclear fuel cycle simulation framework'
-  
+
 - name: cyder
   pic: research/cyder.png
   network: github
   dates: 2011-2013
   role: Huff, original creator and continued contributor.
-  src: https://github.com/arfc/cyder
+  src: https://github.com/arfc/cyder#readme
   url: https://arfc.github.io/cyder
   description: 'Cyder is an integrated used fuel disposition and generic repository model for fuel cycle analysis. (C++) This was Prof. Huffs ph.d. dissertation work.'
 

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -21,8 +21,8 @@
   network: github
   dates: 2011-2013
   role: Huff, original creator and continued contributor.
-  src: https://github.com/arfc/cyder#readme
-  url: https://arfc.github.io/cyder
+  src: https://github.com/arfc/cyder
+  url: https://github.com/arfc/cyder#readme
   description: 'Cyder is an integrated used fuel disposition and generic repository model for fuel cycle analysis. (C++) This was Prof. Huffs ph.d. dissertation work.'
 
 - name: pyne


### PR DESCRIPTION
## Summary of changes
<!--- In one or more sentences, describe the PR you are submitting -->
Changes the docs link for Cyder to direct to the README instead of a depreciated link.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Associated Issues and PRs
<!--- Please note any issues or pull requests associated with this pull request -->

- Issue: closes #272


## Associated Developers
<!--- Please mention any developers who should be alerted of this PR -->

- Dev: n/a


## Checklist for Reviewers

Reviewers should use [this link](/manual/guides/pull_requests) to get to the 
Review Checklist before they begin their review.
