### PR TITLE
Fix Cyder link and Ceser's profile entry

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -16,7 +16,7 @@
     - subtitle: "cyclus"
       suburl: "https://fuelcycle.org"
     - subtitle: "cyder"
-      suburl: "https://arfc.github.io/cyder"
+      suburl: "https://github.com/arfc/cyder#readme"
     - subtitle: "moltres"
       suburl: "/software/moltres"
     - subtitle: "pyne"

--- a/_data/people.yml
+++ b/_data/people.yml
@@ -146,12 +146,12 @@
       icon: linkedin
       name: LinkedIn
 
--name: Ceser Zambrano
- pic: /img/people/zambranoc.png
- dates: 2023-present
- role: Undergraduate Research Assistant
- description: 'Ceser is an undergraduate in NPRE at UIUC. He is interested in the usage of simulations for reactor cores. '
- social:
+- name: Ceser Zambrano
+  pic: /img/people/zambranoc.png
+  dates: 2023-present
+  role: Undergraduate Research Assistant
+  description: 'Ceser is an undergraduate in NPRE at UIUC. He is interested in the usage of simulations for reactor cores. '
+  social:
     - url: mailto:ceserz2@illinois.edu
       icon: envelope-o
       name: Email


### PR DESCRIPTION
## Summary of changes
<!--- In one or more sentences, describe the PR you are submitting -->
Fixes #282. Fixes Ceser's profile entry syntax in the people.yml file (missing whitespace), which broke [deployment](https://github.com/arfc/arfc.github.io/actions/runs/5150169906).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Associated Issues and PRs
<!--- Please note any issues or pull requests associated with this pull request -->

- Issue: #282

## Associated Developers
<!--- Please mention any developers who should be alerted of this PR -->

## Checklist for Reviewers

Reviewers should use [this link](/manual/guides/pull_requests.md) to get to the 
Review Checklist before they begin their review.
