### PR TITLE
Make link from the PR template absolute to website checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,5 +30,5 @@
 
 ## Checklist for Reviewers
 
-Reviewers should use [this link](/manual/guides/pull_requests.md) to get to the 
+Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the
 Review Checklist before they begin their review.


### PR DESCRIPTION
## Summary of changes
This PR closes #320 by making the link from the PR template absolute to the PR Review Checklist on the website instead of relative. The relative link wasn't working from actual PRs (you can see in this PR how the relative link wasn't working).

Requesting @RhysMacMillan so he can practice reviewing a PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Associated Issues and PRs
<!--- Please note any issues or pull requests associated with this pull request -->

- Issue: #320 


## Associated Developers
<!--- Please mention any developers who should be alerted of this PR -->

- Dev: @RhysMacMillan 


## Checklist for Reviewers

Reviewers should use [this link](/manual/guides/pull_requests.md) to get to the 
Review Checklist before they begin their review.
