### PR TITLE
Fix: MOOSE install link in guides

### DIFF
--- a/manual/guides/guides.md
+++ b/manual/guides/guides.md
@@ -95,7 +95,7 @@ twitter accounts, and whatnot that tie us together.
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [Python](https://realpython.com/installing-python/)
 - [PyNE](/manual/guides/pyne)
-- [MOOSE](https://moose.inl.gov/SitePages/Home.aspx)
+- [MOOSE](https://mooseframework.inl.gov/getting_started/installation/)
 - [Cyclus](/manual/guides/cyclus)
 
 # Software


### PR DESCRIPTION
## Summary of changes
<!--- In one or more sentences, describe the PR you are submitting -->
MOOSE installation link in the manual/guides page is broken and does not lead to a site. This PR updates this link to the correct link, leading to the installation guide on MOOSE's website.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


## Checklist for Reviewers

Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the
Review Checklist before they begin their review.
