### PR TITLE
adds padding to tables

### DIFF
--- a/_includes/css/agency.css
+++ b/_includes/css/agency.css
@@ -4,6 +4,10 @@
  * For details, see http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+th, td {
+  padding: 20px;
+}
+
 body {
     overflow-x: hidden;
     font-family: "Roboto Slab","Helvetica Neue",Helvetica,Arial,sans-serif;

--- a/_includes/css/agency.css
+++ b/_includes/css/agency.css
@@ -5,7 +5,7 @@
  */
 
 th, td {
-  padding: 20px;
+  padding: 10px;
 }
 
 body {


### PR DESCRIPTION
## Summary of changes
The padding in markdown tables seemed a little squished. I've added 20px vertically and horizontally in the css. The problem was that it previously looked like this:

![image](https://github.com/user-attachments/assets/622e1321-9f44-4520-a2e9-014b9e2fd4c5)

The change should make it look like: 
![image](https://github.com/user-attachments/assets/19b3daee-dbea-49e6-9c16-a5851ea606a5)



## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Associated Issues and PRs

- Issue: #400 
- PR #399 

## Associated Developers

- Dev: @yardasol 


## Checklist for Reviewers

Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the
Review Checklist before they begin their review.
