### PR TITLE
Update group publications list according to group Zotero

### DIFF
--- a/_bibliography/references.bib
+++ b/_bibliography/references.bib
@@ -1,28 +1,5 @@
-@article{seifert_delayed_2025,
-  title={Delayed Neutron Precursor Group Parameter and Spectra Generation from Fast Fission of 235U in SCALE},
-  author={Seifert, Luke and Betzler, Benjamin and Wieselquist, William and Jessee, Matthew and Munk, Madicken and Huff, Kathryn},
-  journal={Nuclear Science and Engineering},
-  pages={1--16},
-  abstract={Delayed neutron precursor (DNP) group data are important for modeling reactor dynamics. Although the data for individual DNPs have been developed over time, the DNP group data present in the Evaluated Nuclear Data Files (ENDF) have not been updated in the past 20 years. In this work, we use SCALE to recreate the Godiva experiment that was used to generate the original DNP group structure for fast fission of 235U. However, each DNP is modeled using up-to-date data, and the results are then converted into a newly updated group structure. This conversion uses an iterative linear least squares solver to minimize chi-squared. The approaches used in this work also enable energy spectrum generation and uncertainty tracking. The method used in this paper for fast 235U fission DNP group structure updating can be applied to different energies and fissile nuclides. Demonstration of the uncertainty tracking in reactor kinetics and dynamics simulations is shown using point reactor kinetics simulations. Results show that there are data discrepancies between the International Atomic Energy Agency database and data used in ORIGEN, which are currently being fixed. Results also show that the proposed method for group spectra generation performs well.},
-  year={2025},
-  publisher={Taylor \& Francis}
-}
-
-@inproceedings{park_hybrid_2025,
-	address = {Denver, CO},
-	title = {A {Hybrid} {SN}-{Diffusion} {Method} for {Molten} {Salt} {Reactor} {Control} {Rod} {Modeling}},
-	url = {https://www.ans.org/pubs/proceedings/article-58077/},
-	doi = {doi.org/10.13182/MC25-47048},
-	booktitle = {Proceedings of {The} {International} {Conference} on {Mathematics} and {Computational} {Methods} {Applied} to {Nuclear} {Science} and {Engineering} ({M}\&{C} 2025)},
-	publisher = {American Nuclear Society},
-	author = {Park, Sun Myung and Huff, Kathryn D and Munk, Madicken},
-	month = apr,
-	year = {2025},
-	pages = {430--439}
-}
 
 @mastersthesis{yardas_implementation_2023,
-	type = {Masters Thesis},
 	title = {Implementation and validation of {OpenMC} depletion capabilities in {SaltProc}},
 	copyright = {Copyright 2023 Oleksandr Redin Yardas},
 	url = {https://hdl.handle.net/2142/121954},
@@ -45,7 +22,7 @@
 
 @mastersthesis{richter_isotopic_2022,
 	address = {Urbana, IL},
-	title = {{ISOTOPIC} {AND} {REACTOR} {PHYSICS} {CHARACTERIZATION} {OF} {A} {GAS}-{COOLED}, {PEBBLE}-{BED} {MICROREACTOR}},
+	title = {Isotopic and reator physics characterization of a gas-cooled, pebble-bed microreactor},
 	language = {en},
 	school = {University of Illinois at Urbana-Champaign},
 	author = {Richter, Zoë},
@@ -81,6 +58,7 @@
 	author = {Kamuda, Mark and Zhao, Jifu and Huff, Kathryn},
 	month = jun,
 	year = {2018},
+	keywords = {Include File on Website},
 }
 
 @misc{bae_impact_2018,
@@ -147,9 +125,8 @@
 	author = {Lindsay, Alexander and Ridley, Gavin and Rykhlevskii, Andrei and Huff, Kathryn},
 	month = apr,
 	year = {2018},
-	keywords = {Reactor physics, Multiphysics, nuclear engineering, agent based modeling, Finite elements, Hydrologic contaminant transport, MOOSE, Nuclear fuel cycle, Object orientation, Parallel computing, repository, Simulation, Systems analysis},
+	keywords = {Reactor physics, Multiphysics, nuclear engineering, agent based modeling, Finite elements, Hydrologic contaminant transport, MOOSE, Nuclear fuel cycle, Object orientation, Parallel computing, repository, Simulation, Systems analysis, Include File on Website},
 	pages = {530--540},
-	annote = {2d prescribed},
 }
 
 @misc{huff_enabling_2018,
@@ -233,15 +210,15 @@ ment quantification problem which shows an accuracy useful for homeland security
 	month = jun,
 	year = {2019},
 	note = {https://zenodo.org/record/3354507},
-	keywords = {nuclear fuel cycle, arfc, report, cyclus},
+	keywords = {nuclear fuel cycle, arfc, report, cyclus, Include File on Website},
 	pages = {1--23},
-	annote = {This research is being performed using funding received from the Department of Energy (DOE) Office of Nuclear Energy's Nuclear Energy University Program (Project 16-10512, DE-NE0008567) 'Demand-Driven Cycamore Archetypes'.},
 }
 
 @mastersthesis{westphal_modeling_2019,
 	address = {Urbana, IL},
 	title = {Modeling {Special} {Nuclear} {Material} {Diversion} from a {Pyroprocessing} {Facility}},
 	copyright = {Copyright 2019 Greg Westphal},
+	url = {https://hdl.handle.net/2142/106275},
 	abstract = {As a result of the once-through fuel cycle implemented in the US, used nuclear fuel (UNF)
 steadily increases. One proposed solution is the transition to a closed nuclear fuel cycle, in
 which reprocessing reduces build up of UNF. Pyroprocessing is an attractive method for this
@@ -291,7 +268,7 @@ These prediction models are being developed by the University of South Carolina.
 	author = {Bae, Jin Whan and Chee, Gwendolyn and Huff, Kathryn},
 	month = apr,
 	year = {2018},
-	keywords = {arfc, report},
+	keywords = {arfc, report, Include File on Website},
 	pages = {0--21},
 }
 
@@ -308,6 +285,7 @@ These prediction models are being developed by the University of South Carolina.
 	author = {Andreades, Charalampos and Cisneros, Anselmo T. and Choi, Jae Keun and Chong, Alexandre YK and Fratoni, Massimiliano and Hong, Sea and Huddar, Lakshana R. and Huff, Kathryn D. and Kendrick, James and Krumwiede, David L. and Laufer, Michael and Munk, Madicken and Scarlat, Raluca O. and Wang, Xin and Zwiebaum, Nicolas and Greenspan, Ehud and Peterson, Per},
 	month = sep,
 	year = {2016},
+	keywords = {Include File on Website},
 	pages = {222--238},
 }
 
@@ -325,7 +303,7 @@ respectively, are presented. Finally, a digital filter designed to improve the d
 	author = {Rochman, D. and Haight, R. C. and Wender, S. A. and O'Donnell, J. M. and Michaudon, A. and Huff, Kathryn D. and Vieira, D. J. and Bond, E. and Rundberg, R. S. and Kronenberg, A. and Wilhelmy, J. and Bredeweg, T. A. and Schwantes, J. and Ethvignot, T. and Granier, T. and Petit, M. and Danon, Y.},
 	month = may,
 	year = {2005},
-	keywords = {=A, 220{\textless}, Neutron-induced fission, Nucleon-induced reactions, Spectrometers and spectroscopic techniques},
+	keywords = {=A, 220{\textless}, Neutron-induced fission, Nucleon-induced reactions, Spectrometers and spectroscopic techniques, Include File on Website},
 	pages = {736--739},
 }
 
@@ -363,7 +341,7 @@ Here we present results of the GENIUSv2 testing suite which demonstrate neutroni
 	author = {Mujica, Nicolas and Clerc, Marcel and Cordero, Patricio and Dunstan, Jocelyn and Huff, Kathryn D. and Oyarte, Loreto and Soto, Rodrigo and Varas, German and Risso, Dino},
 	month = nov,
 	year = {2008},
-	keywords = {KHuff},
+	keywords = {KHuff, Include File on Website},
 }
 
 @techreport{huff_next_2010,
@@ -511,9 +489,8 @@ The Dagstuhl Perspectives Workshop on “Engineering Academic Software” has ex
 	author = {Allen, Alice and Aragon, Cecilia and Becker, Christoph and Carver, Jeffrey and Chis, Andrei and Combemale, Benoit and Croucher, Mike and Crowston, Kevin and Garijo, Daniel and Gehani, Ashish and Goble, Carole and Haines, Robert and Hirschfeld, Robert and Howison, James and Huff, Kathryn and Jay, Caroline and Katz, Daniel S. and Kirchner, Claude and Kuksenok, Katie and Lämmel, Ralf and Nierstrasz, Oscar and Turk, Matt and Nieuwpoort, Rob van and Vaughn, Matthew and Vinju, Jurgen J.},
 	editor = {al, Alice Allen et},
 	year = {2017},
-	keywords = {Academic software, Research software, Software citation, Software sustainability},
+	keywords = {Academic software, Research software, Software citation, Software sustainability, Include File on Website},
 	pages = {1--20},
-	annote = {Keywords: Academic software, Research software, Software citation, Software sustainability},
 }
 
 @techreport{ridley_multiphysics_2017,
@@ -530,7 +507,7 @@ open-source software can inform reproducible results suitable for preliminary li
 	month = aug,
 	year = {2017},
 	note = {DOI 10.5281/zenodo.1145437},
-	keywords = {arfc, report},
+	keywords = {arfc, report, Include File on Website},
 	pages = {0--12},
 }
 
@@ -548,6 +525,7 @@ open-source software can inform reproducible results suitable for preliminary li
 	author = {Smith, Arfon M. and Niemeyer, Kyle E. and Katz, Daniel S. and Barba, Lorena A. and Githinji, George and Gymrek, Melissa and Huff, Kathryn D. and Madan, Christopher R. and Mayes, Abigail Cabunoc and Moerman, Kevin M. and Prins, Pjotr and Ram, Karthik and Rokem, Ariel and Teal, Tracy K. and Guimera, Roman Valls and Vanderplas, Jacob T.},
 	month = feb,
 	year = {2018},
+	keywords = {Include File on Website},
 	pages = {e147},
 }
 
@@ -572,7 +550,7 @@ separately.},
 	month = nov,
 	year = {2017},
 	doi = {10.5281/zenodo.1145439},
-	keywords = {arfc, report},
+	keywords = {arfc, report, Include File on Website},
 	pages = {0--12},
 }
 
@@ -791,6 +769,7 @@ separately.},
 	publisher = {SciPy},
 	author = {Huff, Kathryn},
 	year = {2015},
+	keywords = {Include File on Website},
 	pages = {87--93},
 }
 
@@ -817,7 +796,7 @@ separately.},
 	author = {Bae, Jin Whan and Peterson-Droogh, Joshua L. and Huff, Kathryn D.},
 	month = jun,
 	year = {2019},
-	keywords = {Reactor physics, Multiphysics, nuclear engineering, agent based modeling, Finite elements, Hydrologic contaminant transport, MOOSE, Nuclear fuel cycle, Object orientation, Parallel computing, repository, Simulation, Systems analysis, Verification, C},
+	keywords = {Reactor physics, Multiphysics, nuclear engineering, agent based modeling, Finite elements, Hydrologic contaminant transport, MOOSE, Nuclear fuel cycle, Object orientation, Parallel computing, repository, Simulation, Systems analysis, Verification, C, Include File on Website},
 	pages = {288--291},
 }
 
@@ -830,6 +809,7 @@ separately.},
 	author = {Wang, Xin and Huff, Kathryn D. and Aufiero, Manuele and Peterson, Per F. and Fratoni, Massimiliano},
 	month = apr,
 	year = {2016},
+	keywords = {Include File on Website},
 	pages = {Paper 16555},
 }
 
@@ -886,7 +866,7 @@ separately.},
 	author = {Bae, Jin Whan and Singer, Clifford E. and Huff, Kathryn D.},
 	month = jul,
 	year = {2019},
-	keywords = {Reactor physics, Multiphysics, nuclear engineering, agent based modeling, Finite elements, Hydrologic contaminant transport, MOOSE, Nuclear fuel cycle, Object orientation, Parallel computing, repository, Simulation, Systems analysis, Transition, Agent-based, European union, Spent nuclear fuel},
+	keywords = {Reactor physics, Multiphysics, nuclear engineering, agent based modeling, Finite elements, Hydrologic contaminant transport, MOOSE, Nuclear fuel cycle, Object orientation, Parallel computing, repository, Simulation, Systems analysis, Transition, Agent-based, European union, Spent nuclear fuel, Include File on Website},
 	pages = {1--12},
 }
 
@@ -903,6 +883,7 @@ separately.},
 	author = {Scopatz, Anthony M. and Huff, Kathryn D.},
 	month = may,
 	year = {2015},
+	keywords = {Include File on Website},
 }
 
 @misc{huff_neutron_2019-1,
@@ -928,7 +909,7 @@ separately.},
 	author = {Rykhlevskii, Andrei and Bae, Jin Whan and Huff, Kathryn D.},
 	month = jun,
 	year = {2019},
-	keywords = {Python, Molten salt reactor, Reactor physics, Depletion, Multiphysics, nuclear engineering, agent based modeling, Finite elements, Hydrologic contaminant transport, MOOSE, Nuclear fuel cycle, Object orientation, Parallel computing, repository, Simulation, Systems analysis, Molten salt breeder reactor, Online reprocessing, Salt treatment},
+	keywords = {Python, Molten salt reactor, Reactor physics, Depletion, Multiphysics, nuclear engineering, agent based modeling, Finite elements, Hydrologic contaminant transport, MOOSE, Nuclear fuel cycle, Object orientation, Parallel computing, repository, Simulation, Systems analysis, Molten salt breeder reactor, Online reprocessing, Salt treatment, Include File on Website},
 	pages = {366--379},
 }
 
@@ -1069,9 +1050,8 @@ This report details a preliminary analysis to evaluate the potential for utilizi
 	month = apr,
 	year = {2016},
 	note = {arXiv: 1509.03604},
-	keywords = {nuclear engineering, agent based modeling, Nuclear fuel cycle, Object orientation, Simulation, Systems analysis, simulation, Computer Science - Software Engineering, Computer Science - Computational Engineering, Finance, and Science, Computer Science - Mathematical Software, Computer Science - Multiagent Systems, D.2.13, D.2.4, I.6.7, I.6.8, Finance, and Science, Computer Science - Computational Engineering, Agent based modeling, Nuclear engineering},
+	keywords = {nuclear engineering, agent based modeling, Nuclear fuel cycle, Object orientation, Simulation, Systems analysis, simulation, Computer Science - Software Engineering, Computer Science - Computational Engineering, Finance, and Science, Computer Science - Mathematical Software, Computer Science - Multiagent Systems, D.2.13, D.2.4, I.6.7, I.6.8, Finance, and Science, Computer Science - Computational Engineering, Agent based modeling, Nuclear engineering, Include File on Website},
 	pages = {46--59},
-	annote = {arXiv: 1509.03604},
 }
 
 @inproceedings{hague_comparison_2019,
@@ -1097,6 +1077,7 @@ This report details a preliminary analysis to evaluate the potential for utilizi
 	author = {Chee, Gwendolyn J. and Huff, Kathryn D.},
 	month = apr,
 	year = {2019},
+	keywords = {Include File on Website},
 }
 
 @inproceedings{chee_numerical_2018,
@@ -1207,7 +1188,7 @@ and negatively. While fuel cycle advancements also impact fuel costs, this compo
 	month = jan,
 	year = {2019},
 	doi = {10.1016/B978-0-12-813975-2.00001-6},
-	keywords = {Levelized cost of electricity, Economics, Reprocessing, Waste management, Advanced nuclear fuel cycles, Advanced nuclear reactors, Conversion, Enrichment, Fuel cycles, Fuel fabrication, Milling, Mining},
+	keywords = {Levelized cost of electricity, Economics, Reprocessing, Waste management, Advanced nuclear fuel cycles, Advanced nuclear reactors, Conversion, Enrichment, Fuel cycles, Fuel fabrication, Milling, Mining, Include File on Website},
 	pages = {1--20},
 }
 
@@ -1225,7 +1206,7 @@ and negatively. While fuel cycle advancements also impact fuel costs, this compo
 	author = {Kamuda, Mark and Zhao, Jifu and Huff, Kathryn},
 	month = feb,
 	year = {2020},
-	keywords = {Neural networks, Gamma-ray spectroscopy, Automated isotope identification},
+	keywords = {Neural networks, Gamma-ray spectroscopy, Automated isotope identification, Include File on Website},
 	pages = {161385},
 }
 
@@ -1261,6 +1242,7 @@ the design process and reducing the man-hours consumed in modeling.},
 	author = {Huff, Kathryn D.},
 	month = mar,
 	year = {2011},
+	keywords = {Include File on Website},
 }
 
 @article{miernicki_nuclear_2020,
@@ -1277,6 +1259,7 @@ the design process and reducing the man-hours consumed in modeling.},
 	author = {Miernicki, Elizabeth A. and Heald, Alexander L. and Huff, Kathryn D. and Brooks, Caleb S. and Margenot, Andrew J.},
 	month = sep,
 	year = {2020},
+	keywords = {Include File on Website},
 	pages = {121918},
 }
 
@@ -1333,6 +1316,7 @@ evaluations},
 	month = jun,
 	year = {2016},
 	note = {JC0003},
+	keywords = {Include File on Website},
 }
 
 @inproceedings{bates_pyne_2014,
@@ -1377,6 +1361,7 @@ Python 3 support.},
 	publisher = {American Nuclear Society},
 	author = {Krumwiede, David L. and Andreades, C. and Choi, J.K. and Cisneros, A.T. and Huddar, Lakshana and Huff, Kathryn D. and Laufer, M.D. and Munk, Madicken and Scarlat, Raluca O. and Seifried, Jeffrey E. and Zwiebaum, Nicolas and Greenspan, Ehud and Peterson, Per F.},
 	year = {2014},
+	keywords = {Include File on Website},
 }
 
 @inproceedings{huff_cyclus_2013,
@@ -1389,6 +1374,7 @@ Python 3 support.},
 	author = {Huff, Kathryn D.},
 	month = oct,
 	year = {2013},
+	keywords = {Include File on Website},
 }
 
 @inproceedings{gidden_agent-based_2013,
@@ -1402,6 +1388,7 @@ Python 3 support.},
 	author = {Gidden, Matthew and Wilson, Paul and Huff, Kathryn D. and Carlsen, Robert W.},
 	month = sep,
 	year = {2013},
+	keywords = {Include File on Website},
 }
 
 @article{ashraf_strategies_2020,
@@ -1417,7 +1404,7 @@ Python 3 support.},
 	author = {Ashraf, O. and Rykhlevskii, Andrei and Tikhomirov, G. V. and Huff, Kathryn D.},
 	month = dec,
 	year = {2020},
-	keywords = {MSR, Thorium fuel cycle, Online reprocessing, Breeding reactor, Burnup, Monte carlo code, Burner, Transuranic},
+	keywords = {MSR, Thorium fuel cycle, Online reprocessing, Breeding reactor, Burnup, Monte carlo code, Burner, Transuranic, Include File on Website},
 	pages = {107656},
 }
 
@@ -1497,6 +1484,7 @@ more likely to have consenting communities.},
 	author = {Bae, Jin Whan and Roy, William and Huff, Kathryn D.},
 	month = apr,
 	year = {2017},
+	keywords = {Include File on Website},
 	pages = {876--883},
 }
 
@@ -1557,6 +1545,7 @@ from available separated material.},
 	author = {Betzler, Benjamin R. and Rykhlevskii, Andrei and Worrall, Andrew and Huff, Kathryn D.},
 	month = sep,
 	year = {2019},
+	keywords = {Include File on Website},
 }
 
 @inproceedings{rykhlevskii_full-core_2017,
@@ -1725,6 +1714,7 @@ the C YCLUS results.},
 	author = {Park, Sun Myung and Rykhlevskii, Andrei and Huff, Kathryn},
 	month = sep,
 	year = {2019},
+	keywords = {Include File on Website},
 }
 
 @inproceedings{flanagan_methods_2019,
@@ -1736,6 +1726,7 @@ the C YCLUS results.},
 	author = {Flanagan, Robert R. and Bae, Jin Whan and Huff, Kathryn D. and Chee, Gwendolyn J. and Fairhurst, Roberto},
 	month = sep,
 	year = {2019},
+	keywords = {Include File on Website},
 	pages = {402--427},
 }
 
@@ -1826,6 +1817,7 @@ more detailed model.},
 	author = {Westphal, Greg and Huff, Kathryn},
 	month = nov,
 	year = {2018},
+	keywords = {Include File on Website},
 	pages = {73--76},
 }
 
@@ -1851,6 +1843,7 @@ more detailed model.},
 	author = {Chee, Gwendolyn and Bae, Jin Whan and Huff, Kathryn D. and Flanagan, Robert R. and Fairhurst, Roberto},
 	month = sep,
 	year = {2019},
+	keywords = {Include File on Website},
 	pages = {394--401},
 }
 
@@ -1892,6 +1885,7 @@ more detailed model.},
 	author = {Rykhlevskii, Andrei and Betzler, Benjamin R. and Worrall, Andrew and Huff, Kathryn D.},
 	month = aug,
 	year = {2019},
+	keywords = {Include File on Website},
 	pages = {342--353},
 }
 
@@ -1937,6 +1931,7 @@ tributed in this work are examples of such contributions.},
 	author = {Huff, Kathryn D.},
 	month = feb,
 	year = {2013},
+	keywords = {Include File on Website},
 }
 
 @inproceedings{oliver_studying_2009,
@@ -1948,7 +1943,7 @@ tributed in this work are examples of such contributions.},
 	author = {Oliver, Kyle M. and Wilson, Paul P.H. and Reveillere, Arnaud and Ahn, Tae Wook and Dunn, Kerry and Huff, Kathryn D. and Elmore, Royal A.},
 	month = sep,
 	year = {2009},
-	keywords = {Geniusv2, Capacity, Discrete Facility/ Discrete Model (DF/DM), Mass Flow Data, Nuclear Fuel Cycle Facilities, Nuclear Fuel Cycle Systems Analysis Tool},
+	keywords = {Geniusv2, Capacity, Discrete Facility/ Discrete Model (DF/DM), Mass Flow Data, Nuclear Fuel Cycle Facilities, Nuclear Fuel Cycle Systems Analysis Tool, Include File on Website},
 }
 
 @article{clerc_liquid-solid-like_2008,
@@ -1972,7 +1967,7 @@ experimental, numerical and theoretical studies to build a theoretical framework
 	author = {Clerc, M. G. and Cordero, P. and Dunstan, J. and Huff, Kathryn D. and Mujica, N. and Risso, D. and Varas, G.},
 	month = mar,
 	year = {2008},
-	keywords = {KHuff},
+	keywords = {KHuff, Include File on Website},
 	pages = {249--254},
 }
 
@@ -1988,7 +1983,7 @@ experimental, numerical and theoretical studies to build a theoretical framework
 	author = {Wilson, Greg V. and Aruliah, D. A. and Brown, C. Titus and Chue Hong, Neil P. and Davis, Matt and Guy, Richard T. and Haddock, Steven H. D. and Huff, Kathryn D. and Mitchell, Ian M. and Plumbley, Mark D. and Waugh, Ben and White, Ethan P. and Wilson, Paul},
 	month = jan,
 	year = {2014},
-	keywords = {science, Computer Science - Software Engineering, recommendation, Science, software, Computer Science - Mathematical Software},
+	keywords = {science, Computer Science - Software Engineering, recommendation, Science, software, Computer Science - Mathematical Software, Include File on Website},
 	pages = {e1001745},
 }
 
@@ -2084,9 +2079,8 @@ experimental, numerical and theoretical studies to build a theoretical framework
 	month = may,
 	year = {2019},
 	doi = {10.5281/zenodo.3354538},
-	keywords = {arfc, report, i2cner, energy analysis, japan},
+	keywords = {arfc, report, i2cner, energy analysis, japan, Include File on Website},
 	pages = {0--17},
-	annote = {The authors gratefully acknowledge the support of the International Institute for Carbon Neutral Energy Research (WPI-I2CNER), sponsored by the Japanese Ministry of Education, Culture, Sports, Science and Technology.},
 }
 
 @article{chaube_role_2020,
@@ -2105,7 +2099,7 @@ experimental, numerical and theoretical studies to build a theoretical framework
 	year = {2020},
 	note = {Number: 17
 Publisher: Multidisciplinary Digital Publishing Institute},
-	keywords = {sustainability, Japan, energy model, fuel cell, hydrogen economy},
+	keywords = {sustainability, Japan, energy model, fuel cell, hydrogen economy, Include File on Website},
 	pages = {4539},
 }
 
@@ -2121,7 +2115,7 @@ Publisher: Multidisciplinary Digital Publishing Institute},
 	author = {Ashraf, O. and Rykhlevskii, Andrei and Tikhomirov, G.V. and Huff, Kathryn D.},
 	month = mar,
 	year = {2020},
-	keywords = {MSR, Thorium fuel cycle, Online reprocessing, Breeding reactor, Burnup, Monte carlo code},
+	keywords = {MSR, Thorium fuel cycle, Online reprocessing, Breeding reactor, Burnup, Monte carlo code, Include File on Website},
 	pages = {107--115},
 }
 
@@ -2138,7 +2132,7 @@ Publisher: Multidisciplinary Digital Publishing Institute},
 	author = {Chee, Gwendolyn J. and Agosta, Roberto E. Fairhurst and Bae, Jin Whan and Flanagan, Robert R. and Scopatz, Anthony M. and Huff, Kathryn D.},
 	month = jul,
 	year = {2020},
-	keywords = {nuclear fuel cycle, Nuclear engineering, automated deployment, nuclear fuel cycle simulator, time-series forecasting},
+	keywords = {nuclear fuel cycle, Nuclear engineering, automated deployment, nuclear fuel cycle simulator, time-series forecasting, Include File on Website},
 	pages = {1--22},
 }
 
@@ -2157,6 +2151,8 @@ Part 1 provides an accessible introduction to reproducible research, a basic rep
 	author = {Huff, Kathryn},
 	editor = {Kitzes, Justin and Imamoglu, Fatma and Turek, Daniel},
 	year = {2017},
+	note = {url: http://www.practicereproducibleresearch.org/case-studies/khuff.html},
+	keywords = {Include File on Website},
 }
 
 @incollection{huff_lessons_2017,
@@ -2174,6 +2170,8 @@ Part 1 provides an accessible introduction to reproducible research, a basic rep
 	author = {Huff, Kathryn},
 	editor = {Kitzes, Justin and Imamoglu, Fatma and Turek, Daniel},
 	year = {2017},
+	note = {URL: http://www.practicereproducibleresearch.org/core-chapters/5-lessons.html},
+	keywords = {Include File on Website},
 }
 
 @misc{dotson_future_2020,
@@ -2214,7 +2212,6 @@ The greatest source of economic variability is contained in the capital costs of
 
 @mastersthesis{erik_andrew_medhurst_photogrammetry_2020,
 	address = {Urbana, IL},
-	type = {{MS} {Nuclear} {Engineering} and {Engineering} {Physics}},
 	title = {Photogrammetry, {Cloud} {Storage}, {Virtual} {Reality}, and {Augmented} {Reality} to {Guide} {Radiation} {Measurement} {Planning} and {Visualization} {PROCESS}},
 	abstract = {Localizing a radiation source in an urban environment is a challenge in nuclear nonproliferation
 and radiation detection. One approach to localize a source is to send a mobile radiation sensor
@@ -2244,6 +2241,7 @@ thesis concludes with suggestions for future work to approach robust solutions t
 	author = {{Erik Andrew Medhurst}},
 	month = may,
 	year = {2020},
+	note = {degree:MS Nuclear Engineering and Engineering Physics},
 }
 
 @phdthesis{rykhlevskii_fuel_2018,
@@ -2272,6 +2270,7 @@ thesis concludes with suggestions for future work to approach robust solutions t
 	month = jul,
 	year = {2017},
 	note = {10.6084/m9.figshare.5208151.v1},
+	keywords = {Include File on Website},
 }
 
 @techreport{djokic_application_2015,
@@ -2353,6 +2352,7 @@ such as economics and industrial engineering.},
 	author = {Huff, Kathryn D. and Bae, Jin Whan and Mummah, Kathryn A. and Flanagan, Robert R. and Scopatz, Anthony M.},
 	month = sep,
 	year = {2017},
+	keywords = {Include File on Website},
 }
 
 @article{lindsay_moltres_2018,
@@ -2394,6 +2394,7 @@ MOOSE provide and suggests that iteratively coupling codes devoted to single phy
 	author = {Lindsay, Alexander and Huff, Kathryn},
 	month = jan,
 	year = {2018},
+	keywords = {Include File on Website},
 	pages = {1--2},
 }
 
@@ -2410,7 +2411,7 @@ MOOSE provide and suggests that iteratively coupling codes devoted to single phy
 	author = {Bae, Jin Whan and Rykhlevskii, Andrei and Chee, Gwendolyn and Huff, Kathryn D.},
 	month = may,
 	year = {2020},
-	keywords = {Python, Molten salt reactor, Reactor physics, Depletion, Multiphysics, nuclear engineering, agent based modeling, Finite elements, Hydrologic contaminant transport, MOOSE, Nuclear fuel cycle, Object orientation, Parallel computing, repository, Simulation, Systems analysis, Molten salt breeder reactor, Online reprocessing, Salt treatment, Spent nuclear fuel, Machine learning, Artificial neural network},
+	keywords = {Python, Molten salt reactor, Reactor physics, Depletion, Multiphysics, nuclear engineering, agent based modeling, Finite elements, Hydrologic contaminant transport, MOOSE, Nuclear fuel cycle, Object orientation, Parallel computing, repository, Simulation, Systems analysis, Molten salt breeder reactor, Online reprocessing, Salt treatment, Spent nuclear fuel, Machine learning, Artificial neural network, Include File on Website},
 	pages = {107230},
 }
 
@@ -2425,16 +2426,8 @@ MOOSE provide and suggests that iteratively coupling codes devoted to single phy
 	author = {Huff, Kathryn},
 	month = dec,
 	year = {2017},
-	keywords = {nuclear engineering, agent based modeling, Hydrologic contaminant transport, Nuclear fuel cycle, Object orientation, repository, Simulation, Systems analysis, Nuclear Fuel Cycle, simulation, Repository},
+	keywords = {nuclear engineering, agent based modeling, Hydrologic contaminant transport, Nuclear fuel cycle, Object orientation, repository, Simulation, Systems analysis, Nuclear Fuel Cycle, simulation, Repository, Include File on Website},
 	pages = {268--281},
-	annote = {Discussion of what models are used for radionuclide contaminant transport and essentially how the code works. It also discusses the significance of repository modeling.
-Significance
-- Nuclear fuel cycle and nuclear waste disposal decisions are technologically coupled through the characteristics of spent fuel which vary among fuel cycles and impact repository design and performance
-- Dynamic integration of generic disposal model with fuel cycle systems analysis framework is necessary to illuminate performance distinctions of candidate repository host media, designs, and engineering components in the context of fuel cycle options
-- Most current tools treat waste disposal phase of fuel cycle analysis statically in post processing by reporting values such as mass, volumes, radiotoxicity, or heat production of accumulated SNF and high level waste. They fail to address the dynamic impact of the waste streams on the performance of the geologic disposal system.
- 
-Cyder
-- Cyder provides medium fidelity models to conduct repository performance analysis on efficient timescales appropriate for fuel cycle analyses},
 }
 
 @misc{huff_effective_2020,
@@ -2555,7 +2548,9 @@ The goal of Cyclus is to enable a broad spectrum of fuel cycle simulation while 
 	type = {Milestone {Report}},
 	title = {Milestone 2.1 {Report}: {Demonstration} of {SaltProc}},
 	shorttitle = {Contract {DE}-{AR0000983}, {Enabling} {Load} {Following} {Capability} in the {Transatomic} {MSR}},
-	abstract = {The University of Illinois, Urbana-Champaign (UIUC) is engaged in work to develop a fuel processing system that enables load-following in Molten Salt Reactors (MSRs), an important ability that allows nuclear power plants to ramp electricity production up or down to meet changing electricity demand. Nuclear reactions in MSRs produce unwanted byproducts (such as xenon and krypton) that can adversely affect power production. In steady, baseload operation, these byproducts form and decay at the same rate. When electricity production is ramped down, however, the byproducts start to be produced at a greater rate than they decay, leading to a buildup within the reactor. When power production must be once again increased, the response rate is slowed by the time needed for the byproducts to reach their equilibrium level (determined by the radioactive decay half-life, which is on the order of hours). Thus, buildup of these unwanted byproducts resulting from ramping down inhibit proper load following for molten salt reactors. Fortunately, MSRs transport fuel in a flowing molten salt fuel loop, which means that a section of the reactor, outside the core, can be leveraged for fuel processing and "cleanup." The team will determine the feasibility of removal of these unwanted byproducts and de- sign a fuel reprocessing system, removing a major barrier to commercialization for molten salt reactors. Toward this work, we initiated the Fuel Cycle Simulation task (Task 2) in August 2018 to more realistically model the online reprocessing system of the Transatomic Power (TAP) MSR. A Python toolkit, SaltProc v0.1 [1–3], was developed to represent the simplified online fuel salt processing of a Molten Salt Breeder Reactor (MSBR). More recently, an advanced SaltProc version (SaltProc v0.2) was developed to generically simulate complex molten salt fuel reprocessing systems, including the TAP system, incorporating user-parametrized components into the fuel salt processing design. This report summarizes the progress we have made towards milestone M2.1: Demonstrate SaltProc and the steps toward the subsequent Task 2 objectives.},
+	abstract = {The University of Illinois, Urbana-Champaign (UIUC) is engaged in work to develop a fuel processing system that enables load-following in Molten Salt Reactors (MSRs), an important ability that allows nuclear power plants to ramp electricity production up or down to meet changing electricity demand. Nuclear reactions in MSRs produce unwanted byproducts (such as xenon and krypton) that can adversely affect power production. In steady, baseload operation, these byproducts form and decay at the same rate. When electricity production is ramped down, however, the byproducts start to be produced at a greater rate than they decay, leading to a buildup within the reactor. When power production must be once again increased, the response rate is slowed by the time needed for the byproducts to reach their equilibrium level (determined by the radioactive decay half-life, which is on the order of hours). Thus, buildup of these unwanted byproducts resulting from ramping down inhibit proper load following for molten salt reactors. Fortunately, MSRs transport fuel in a flowing molten salt fuel loop, which means that a section of the reactor, outside the core, can be leveraged for fuel processing and "cleanup." The team will determine the feasibility of removal of these unwanted byproducts and de- sign a fuel reprocessing system, removing a major barrier to commercialization for molten salt reactors.
+
+Toward this work, we initiated the Fuel Cycle Simulation task (Task 2) in August 2018 to more realistically model the online reprocessing system of the Transatomic Power (TAP) MSR. A Python toolkit, SaltProc v0.1 [1–3], was developed to represent the simplified online fuel salt processing of a Molten Salt Breeder Reactor (MSBR). More recently, an advanced SaltProc version (SaltProc v0.2) was developed to generically simulate complex molten salt fuel reprocessing systems, including the TAP system, incorporating user-parametrized components into the fuel salt processing design. This report summarizes the progress we have made towards milestone M2.1: Demonstrate SaltProc and the steps toward the subsequent Task 2 objectives.},
 	language = {english},
 	number = {UIUC-ARFC-2019-04 DOI: 10.5281/zenodo.3355649},
 	institution = {University of Illinois at Urbana-Champaign},
@@ -2563,9 +2558,8 @@ The goal of Cyclus is to enable a broad spectrum of fuel cycle simulation while 
 	month = jun,
 	year = {2019},
 	doi = {10.5281/zenodo.3355649},
-	keywords = {nuclear fuel cycle, nuclear engineering, arfc, report, cyclus, molten salt reactor},
+	keywords = {nuclear fuel cycle, nuclear engineering, arfc, report, cyclus, molten salt reactor, Include File on Website},
 	pages = {1--23},
-	annote = {This research is being performed using funding received from the Department of Energy ARPA-E MEITNER Program (award DE-AR0000983) and the Blue Waters sustained-petascale computing project, which is supported by the National Science Foundation (awards OCI-0725070 and ACI-1238993) and the state of Illinois. Blue Waters is a joint effort of the University of Illinois at Urbana-Champaign and its National Center for Supercomputing Applications.},
 }
 
 @article{rykhlevskii_arfc-saltproc_2018,
@@ -2626,9 +2620,8 @@ of young professionals.},
 	month = feb,
 	year = {2019},
 	doi = {10.5281/zenodo.3354563},
-	keywords = {nuclear, molten salt reactor, multiphysics},
+	keywords = {nuclear, molten salt reactor, multiphysics, Include File on Website},
 	pages = {1--12},
-	annote = {This research was performed using funding received from Battelle Energy Alliance LLC, Idaho National Laboratory Standard Research Contract 214196.},
 }
 
 @article{bae_arfc-transition-scenarios_2018-1,
@@ -2704,7 +2697,7 @@ advanced, molten-salt-fueled nuclear reactor.},
 	author = {Smith, Arfon and Barba, Lorena A. and Githinji, George and Gymrek, Melissa and Huff, Kathryn and Katz, Daniel S. and Madan, Christopher and Mayes, Abigail Cabunoc and Moerman, Kevin M. and Niemeyer, Kyle and Prins, Pjotr and Ram, Karthik and Rokem, Ariel and Teal, Tracy and Vanderplas, Jake},
 	month = feb,
 	year = {2017},
-	keywords = {Software citation, JOSS, Open research software, Open software, SIAM-CSE17-PP108},
+	keywords = {Software citation, JOSS, Open research software, Open software, SIAM-CSE17-PP108, Include File on Website},
 }
 
 @article{delbert_tiny_2021,
@@ -2728,7 +2721,12 @@ advanced, molten-salt-fueled nuclear reactor.},
 	type = {Milestone {Report}},
 	title = {Milestone 3.2 {Report}: {Thermal}-{Hydraulics} {Analysis} of {Core} {LoadFollowing} {Operation}},
 	shorttitle = {Contract {DE}-{AR0000983}, {Enabling} {Load} {Following} {Capability} in the {Transatomic} {MSR}},
-	abstract = {The University of Illinois, Urbana-Champaign (UIUC) is engaged in work to develop a fuel processing system that enables load-following in Molten Salt Reactors (MSRs), an important ability that allows nuclear power plants to ramp electricity production up or down to meet changing electricity demand. Nuclear reactions in MSRs produce unwanted byproducts (such as xenon and krypton) that can adversely affect power production. In steady, baseload operation, these byproducts form and decay at the same rate. When electricity production is ramped down, however, the byproducts start to be produced at a greater rate than they decay, leading to a buildup within the reactor. When power production must be once again increased, the response rate is slowed by the time needed for the byproducts to reach their equilibrium level (determined by the radioactive decay half-life, which is on the order of hours). Thus, buildup of these unwanted byproducts resulting from ramping down inhibit proper load following for molten salt reactors. Fortunately, MSRs transport fuel in a flowing molten salt fuel loop, which means that a section of the reactor, outside the core, can be leveraged for fuel processing and "cleanup." The team will determine the feasibility of removal of these unwanted byproducts and de- sign a fuel reprocessing system, removing a major barrier to commercialization for molten salt reactors. The University of Illinois, Urbana-Champaign (UIUC) performed a study in August 2019 to analyze the neutronics behavior of the Transatomic Power Molten Salt Reactor (TAP MSR) core during loadfollowing operations, culminating in the Milestone 3.1 Report [1] . As a follow-up to the previous work, we will be analyzing the thermal-hydraulics behavior of the TAP MSR in this work.},
+	abstract = {The University of Illinois, Urbana-Champaign (UIUC) is engaged in work to develop a fuel processing system that enables load-following in Molten Salt Reactors (MSRs), an important ability that allows nuclear power plants to ramp electricity production up or down to meet changing electricity demand. Nuclear reactions in MSRs produce unwanted byproducts (such as xenon and krypton) that can adversely affect power production. In steady, baseload operation, these byproducts form and decay at the same rate. When electricity production is ramped down, however, the byproducts start to be produced at a greater rate than they decay, leading to a buildup within the reactor. When power production must be once again increased, the response rate is slowed by the time needed for the byproducts to reach their equilibrium level (determined by the radioactive decay half-life, which is on the order of hours). Thus, buildup of these unwanted byproducts resulting from ramping down inhibit proper load following for molten salt reactors. Fortunately, MSRs transport fuel in a flowing molten salt fuel loop, which means that a section of the reactor, outside the core, can be leveraged for fuel processing and "cleanup." The team will determine the feasibility of removal of these unwanted byproducts and de- sign a fuel reprocessing system, removing a major barrier to commercialization for molten salt reactors.
+
+The University of Illinois, Urbana-Champaign (UIUC) performed a study in August 2019 to analyze the
+neutronics behavior of the Transatomic Power Molten Salt Reactor (TAP MSR) core during
+loadfollowing operations, culminating in the Milestone 3.1 Report [1] . As a follow-up to the previous
+work, we will be analyzing the thermal-hydraulics behavior of the TAP MSR in this work.},
 	language = {english},
 	number = {UIUC-ARTS-2020-08},
 	institution = {University of Illinois at Urbana-Champaign},
@@ -2778,7 +2776,9 @@ The Nuclear News staff hopes that you enjoy meet- ing these members of our commu
 	type = {Colloquium},
 	title = {The {Essential} {Role} of {Universities} in {Advanced} {Reactor} {Deployment}},
 	url = {https://nuc.berkeley.edu/the-essential-role-of-universities-in-advanced-reactor-deployment/},
-	abstract = {Many University TRTRs were shut down in the 1980s \& 1990s as student enrollments waned. In the 2000s, student enrollment in nuclear engineering and enthusiasm for carbon-free nuclear energy has rebounded mightily, but no new university TRTRs have been built in nearly 30 years. Simultaneous with this widening gap in hands-on training, unprecedented federal funding to demonstrate and commercialize advanced reactors has been distributed to companies promising a bright future for advanced nuclear energy. But, in this future, who will objectively test these reactors, train their operators, educate their reactor engineers, and improve the technology through innovative experiments? In this talk, I'll suggest that universities remain poised to play many of these roles in the future of next-generation nuclear reactor deployment and university campuses are uniquely suited for early deployments. We at UIUC envision a next-generation university test, research, and training reactor that could underpin advanced reactor commercialization toward national leadership in a clean, sustainable energy future. Our vision for the deployment of a next-generation university TRTR aims to amplify the profound expertise at campuses in research, education, and power production to address the urgent need for advanced reactor prototype testing as well as next-generation research toward integration with carbon-free energy technologies. I will describe a vision of the future in which universities and their research can and must play a significant role in prototype testing next-generation reactors, support commercial licensing and deployment, conduct operations research, drive innovations in associated technologies, and train a next-generation workforce to operate and maintain these next-generation devices.},
+	abstract = {Many University TRTRs were shut down in the 1980s \& 1990s as student enrollments waned. In the 2000s, student enrollment in nuclear engineering and enthusiasm for carbon-free nuclear energy has rebounded mightily, but no new university TRTRs have been built in nearly 30 years. Simultaneous with this widening gap in hands-on training, unprecedented federal funding to demonstrate and commercialize advanced reactors has been distributed to companies promising a bright future for advanced nuclear energy. But, in this future, who will objectively test these reactors, train their operators, educate their reactor engineers, and improve the technology through innovative experiments?
+
+In this talk, I'll suggest that universities remain poised to play many of these roles in the future of next-generation nuclear reactor deployment and university campuses are uniquely suited for early deployments. We at UIUC envision a next-generation university test, research, and training reactor that could underpin advanced reactor commercialization toward national leadership in a clean, sustainable energy future. Our vision for the deployment of a next-generation university TRTR aims to amplify the profound expertise at campuses in research, education, and power production to address the urgent need for advanced reactor prototype testing as well as next-generation research toward integration with carbon-free energy technologies. I will describe a vision of the future in which universities and their research can and must play a significant role in prototype testing next-generation reactors, support commercial licensing and deployment, conduct operations research, drive innovations in associated technologies, and train a next-generation workforce to operate and maintain these next-generation devices.},
 	author = {Huff, Kathryn D.},
 	month = jan,
 	year = {2021},
@@ -2824,7 +2824,7 @@ Craig Piercy, ANS Executive Director/CEO},
 	author = {Ashraf, O. and Rykhlevskii, Andrei and Tikhomirov, G. V. and Huff, Kathryn D.},
 	month = mar,
 	year = {2021},
-	keywords = {Monte Carlo, MSR, Safety, Thorium fuel cycle, Reactivity, Online reprocessing, Breeding reactor, Burnup, Monte carlo code, Control rod},
+	keywords = {Monte Carlo, MSR, Safety, Thorium fuel cycle, Reactivity, Online reprocessing, Breeding reactor, Burnup, Monte carlo code, Control rod, Include File on Website},
 	pages = {108035},
 }
 
@@ -2900,7 +2900,9 @@ Craig Piercy, ANS Executive Director/CEO},
 	type = {Conference},
 	title = {The {Role} of {Universities} in {Advanced} {Reactor} {Deployment}},
 	url = {https://trtr.org/wp-content/uploads/2020/10/2020-TRTR-Program.pdf},
-	abstract = {Many University TRTRs were shut down in the 1980s \& 1990s as student enrollments waned. In the 2000s, student enrollment in nuclear engineering and enthusiasm for carbon-free nuclear energy has rebounded mightily, but no new university TRTRs have been built in nearly 30 years. Simultaneous with this widening gap in hands-on training, unprecedented federal funding to demonstrate and commercialize advanced reactors has been distributed to companies promising a bright future for advanced nuclear energy. But, in this future, who will objectively test these reactors, train their operators, educate their reactor engineers, and improve the technology through innovative experiments? In this talk, I'll suggest that universities remain poised to play many of these roles in the future of next-generation nuclear reactor deployment and university campuses are uniquely suited for early deployments. We at UIUC envision a next-generation university test, research, and training reactor that could underpin advanced reactor commercialization toward national leadership in a clean, sustainable energy future. Our vision for the deployment of a next-generation university TRTR aims to amplify the profound expertise at campuses in research, education, and power production to address the urgent need for advanced reactor prototype testing as well as next-generation research toward integration with carbon-free energy technologies. I will describe a vision of the future in which universities and their research can and must play a significant role in prototype testing next-generation reactors, support commercial licensing and deployment, conduct operations research, drive innovations in associated technologies, and train a next-generation workforce to operate and maintain these next-generation devices.},
+	abstract = {Many University TRTRs were shut down in the 1980s \& 1990s as student enrollments waned. In the 2000s, student enrollment in nuclear engineering and enthusiasm for carbon-free nuclear energy has rebounded mightily, but no new university TRTRs have been built in nearly 30 years. Simultaneous with this widening gap in hands-on training, unprecedented federal funding to demonstrate and commercialize advanced reactors has been distributed to companies promising a bright future for advanced nuclear energy. But, in this future, who will objectively test these reactors, train their operators, educate their reactor engineers, and improve the technology through innovative experiments?
+
+In this talk, I'll suggest that universities remain poised to play many of these roles in the future of next-generation nuclear reactor deployment and university campuses are uniquely suited for early deployments. We at UIUC envision a next-generation university test, research, and training reactor that could underpin advanced reactor commercialization toward national leadership in a clean, sustainable energy future. Our vision for the deployment of a next-generation university TRTR aims to amplify the profound expertise at campuses in research, education, and power production to address the urgent need for advanced reactor prototype testing as well as next-generation research toward integration with carbon-free energy technologies. I will describe a vision of the future in which universities and their research can and must play a significant role in prototype testing next-generation reactors, support commercial licensing and deployment, conduct operations research, drive innovations in associated technologies, and train a next-generation workforce to operate and maintain these next-generation devices.},
 	author = {Huff, Kathryn D.},
 	month = sep,
 	year = {2020},
@@ -2936,7 +2938,9 @@ We analysed the flow around an MSRE graphite stringer using large eddy simulatio
 	type = {Milestone {Report}},
 	title = {Milestone 2.3 {Report}: {SaltProc} {Sensitivity} {Analysis}, {Fuel} processing system design},
 	shorttitle = {Contract {DE}-{AR0000983}, {Enabling} {Load} {Following} {Capability} in the {Transatomic} {MSR}},
-	abstract = {The University of Illinois, Urbana-Champaign (UIUC) is engaged in work to develop a fuel processing system that enables load-following in Molten Salt Reactors (MSRs), an important ability that allows nuclear power plants to ramp electricity production up or down to meet changing electricity demand. Nuclear reactions in MSRs produce unwanted byproducts (such as xenon and krypton) that can adversely affect power production. In steady, baseload operation, these byproducts form and decay at the same rate. When electricity production is ramped down, however, the byproducts start to be produced at a greater rate than they decay, leading to a buildup within the reactor. When power production must be once again increased, the response rate is slowed by the time needed for the byproducts to reach their equilibrium level (determined by the radioactive decay half-life, which is on the order of hours). Thus, buildup of these unwanted byproducts resulting from ramping down inhibit proper load following for molten salt reactors. Fortunately, MSRs transport fuel in a flowing molten salt fuel loop, which means that a section of the reactor, outside the core, can be leveraged for fuel processing and "cleanup." The team will determine the feasibility of removal of these unwanted byproducts and de- sign a fuel reprocessing system, removing a major barrier to commercialization for molten salt reactors. Toward this work, we initiated the Fuel Cycle Simulation task (Task 2) in August 2018 to more realistically model the online reprocessing system of the Transatomic Power (TAP) MSR. A Python toolkit, SaltProc v0.1 [1–3], was developed to represent the simplified online fuel salt processing of a Molten Salt Breeder Reactor (MSBR). More recently, an advanced SaltProc version (SaltProc v0.2) was developed to generically simulate complex molten salt fuel reprocessing systems, including the TAP system, incorporating user-parametrized components into the fuel salt processing design. This report summarizes the progress we have made towards milestone M2.1: Demonstrate SaltProc and the steps toward the subsequent Task 2 objectives.},
+	abstract = {The University of Illinois, Urbana-Champaign (UIUC) is engaged in work to develop a fuel processing system that enables load-following in Molten Salt Reactors (MSRs), an important ability that allows nuclear power plants to ramp electricity production up or down to meet changing electricity demand. Nuclear reactions in MSRs produce unwanted byproducts (such as xenon and krypton) that can adversely affect power production. In steady, baseload operation, these byproducts form and decay at the same rate. When electricity production is ramped down, however, the byproducts start to be produced at a greater rate than they decay, leading to a buildup within the reactor. When power production must be once again increased, the response rate is slowed by the time needed for the byproducts to reach their equilibrium level (determined by the radioactive decay half-life, which is on the order of hours). Thus, buildup of these unwanted byproducts resulting from ramping down inhibit proper load following for molten salt reactors. Fortunately, MSRs transport fuel in a flowing molten salt fuel loop, which means that a section of the reactor, outside the core, can be leveraged for fuel processing and "cleanup." The team will determine the feasibility of removal of these unwanted byproducts and de- sign a fuel reprocessing system, removing a major barrier to commercialization for molten salt reactors.
+
+Toward this work, we initiated the Fuel Cycle Simulation task (Task 2) in August 2018 to more realistically model the online reprocessing system of the Transatomic Power (TAP) MSR. A Python toolkit, SaltProc v0.1 [1–3], was developed to represent the simplified online fuel salt processing of a Molten Salt Breeder Reactor (MSBR). More recently, an advanced SaltProc version (SaltProc v0.2) was developed to generically simulate complex molten salt fuel reprocessing systems, including the TAP system, incorporating user-parametrized components into the fuel salt processing design. This report summarizes the progress we have made towards milestone M2.1: Demonstrate SaltProc and the steps toward the subsequent Task 2 objectives.},
 	language = {english},
 	number = {UIUC-ARFC-2021-01},
 	institution = {University of Illinois at Urbana-Champaign},
@@ -2945,7 +2949,7 @@ We analysed the flow around an MSRE graphite stringer using large eddy simulatio
 	collaborator = {Lee, Alvin and Zhen, Li and Rykhlevskii, Andrei},
 	month = mar,
 	year = {2021},
-	keywords = {nuclear fuel cycle, nuclear engineering, arfc, report, cyclus, molten salt reactor},
+	keywords = {nuclear fuel cycle, nuclear engineering, arfc, report, cyclus, molten salt reactor, Include File on Website},
 	pages = {1--26},
 }
 
@@ -2964,7 +2968,7 @@ Previous energy systems research has shown that such clean energy goals cannot b
 	editor = {Huff, Kathryn D. and Munk, Madicken},
 	month = may,
 	year = {2021},
-	keywords = {nuclear fuel cycle, arfc, report, cyclus},
+	keywords = {nuclear fuel cycle, arfc, report, cyclus, Include File on Website},
 	pages = {1--20},
 }
 
@@ -3047,7 +3051,7 @@ Join the Department of Energy’s Kathryn Huff, the Acting Assistant Secretary a
 
 @inproceedings{bachmann_comparing_2021,
 	address = {Virtual Meeting},
-	title = {Comparing {HALEU} {Demand} {Aong} {Advanced} {Reactor} {Fuel} {Cycle} {Transitions}},
+	title = {Comparing {HALEU} {Demand} {Among} {Advanced} {Reactor} {Fuel} {Cycle} {Transitions}},
 	volume = {124},
 	url = {https://www.ans.org/pubs/transactions/article-49551/},
 	urldate = {2021-06-29},
@@ -3084,6 +3088,7 @@ Join the Department of Energy’s Kathryn Huff, the Acting Assistant Secretary a
 	month = oct,
 	year = {2021},
 	note = {(Submitted before May 2021)},
+	keywords = {Include File on Website},
 	pages = {1924--1933},
 }
 
@@ -3114,6 +3119,7 @@ Join the Department of Energy’s Kathryn Huff, the Acting Assistant Secretary a
 	author = {Bachmann, Amanda M. and Fairhurst-Agosta, Roberto and Richter, Zoë and Ryan, Nathan and Munk, Madicken},
 	year = {2021},
 	note = {Publisher: EDP Sciences},
+	keywords = {Include File on Website},
 	pages = {22},
 }
 
@@ -3191,10 +3197,6 @@ The results demonstrated that time is saved if a comprehensive sensitivity analy
 	month = nov,
 	year = {2020},
 	doi = {10.5281/zenodo.4557613},
-	annote = {This material is based upon work supported under an Integrated University Program Graduate
-Fellowship. Any opinions, findings, conclusions or recommendations expressed in this publication are
-those of the author(s) and do not necessarily reflect the views of the Department of Energy
-Office of Nuclear Energy.},
 }
 
 @mastersthesis{fairhurst-agosta_multi-physics_2020,
@@ -3254,6 +3256,8 @@ currently planned.},
 	author = {Park, Sun Myung and Munk, Madicken},
 	month = aug,
 	year = {2022},
+	note = {Publisher: Elsevier},
+	keywords = {Include File on Website},
 	pages = {109111},
 }
 
@@ -3290,11 +3294,12 @@ currently planned.},
 	author = {Djokic, Denia and Scopatz, Anthony M. and Greenberg, Harris R. and Huff, Kathryn D. and Nibbelink, Russell P. and Fratoni, Massimiliano},
 	month = sep,
 	year = {2015},
+	keywords = {Include File on Website},
 }
 
 @phdthesis{chee_fluoride-salt-cooled_2022,
 	address = {Urbana, IL},
-	type = {Dissertation},
+	type = {Doctoral {Dissertation}},
 	title = {Fluoride-{Salt}-{Cooled} {High} {Temperature} {Reactor} {Design} {Optimization} with {Evolutionary} {Algorithms}},
 	copyright = {Copyright 2021 Gwendolyn Jin Yi Chee},
 	url = {https://github.com/arfc/2022-chee-dissertation},
@@ -3312,11 +3317,11 @@ currently planned.},
 	author = {Bachmann, Amanda M. and Richards, Scott and Munk, Madicken and Feng, Bo},
 	month = nov,
 	year = {2022},
+	keywords = {Include File on Website},
 }
 
 @mastersthesis{dotson_influence_2022,
 	address = {Urbana, IL},
-	type = {Masters Thesis},
 	title = {The influence of temporal detail and inter-annual resource variability on energy planning models},
 	copyright = {Copyright 2022 Samuel G. Dotson},
 	url = {https://hdl.handle.net/2142/115793},
@@ -3378,11 +3383,11 @@ The results of the time resolution study showed that any temporal aggregation ab
 	note = {media},
 }
 
-@phdthesis{dotson_towards_2024,
+@phdthesis{dotson_towards_2025,
 	address = {Champaign, IL},
-	type = {Prelim},
+	type = {Dissertation},
 	title = {Towards a {Holistic} {Integration} of {Energy} {Justice} and {Energy} {System} {Engineering}},
-	copyright = {Copyright 2024 Samuel G. Dotson},
+	copyright = {Copyright 2025 Samuel G. Dotson},
 	abstract = {Climate change produced by greater atmospheric CO2 concentrations from human activity has led to
 increased exposure to hazards worldwide and domestically: increased storm severity, rising sea levels, more
 extreme temperatures, hotter summers, and rising sea levels to name a few. Without immediate action to
@@ -3392,11 +3397,10 @@ dioxide levels (along with other greenhouse gases (GHGs)). Therefore, to achieve
 shared goal of halting and reversing the effects of climate change, our globalized society must transition
 away from fossil fuels to clean energy technologies such as nuclear and renewable energy and switch our
 transportation systems to electric or hydrogen powered vehicles.},
-	language = {en},
 	school = {University of Illinois Urbana-Champaign},
 	author = {Dotson, Samuel G.},
-	month = jan,
-	year = {2024},
+	month = oct,
+	year = {2025},
 }
 
 @misc{shaw_us_2024,
@@ -3589,10 +3593,10 @@ The event includes a reception, dinner, and lecturer. Distinguished guest speake
 	urldate = {2024-05-23},
 	journal = {Mechanical Engineering},
 	author = {Huff, Kathryn},
-	month = jan,
+	month = dec,
 	year = {2022},
 	note = {Publisher: American Society of Mechanical Engineers},
-	keywords = {AMERICA, CLEAN energy, FAST reactors, FUEL cycle, NUCLEAR energy, NUCLEAR fission, NUCLEAR power plants, NUCLEAR reactors},
+	keywords = {AMERICA, CLEAN energy, FAST reactors, FUEL cycle, NUCLEAR energy, NUCLEAR fission, NUCLEAR power plants, NUCLEAR reactors, Include File on Website},
 	pages = {16--16},
 }
 
@@ -4105,16 +4109,15 @@ NE supports R\&D cooperation across borders to ensure research focuses on peacef
 	keywords = {Monte Carlo, Microreactor},
 }
 
-@article{anderson_cyclus_2024,
-	title = {Cyclus v1.6.0},
+@misc{anderson_cyclus_2024,
+	title = {Cyclus},
 	url = {https://figshare.com/articles/software/Cyclus_v1_6_0/25752558},
-	doi = {10.6084/m9.figshare.25752558.v1},
 	abstract = {Release 1.6.0 of the Cyclus Project:
 
 Cyclus is the next-generation agent-based nuclear fuel cycle simulator, providing flexibility to users and developers through a dynamic resource exchange solver and plug-in, user-developed agent framework.
 
 The goal of Cyclus is to enable a broad spectrum of fuel cycle simulation while providing a low barrier to entry for new users and agent developers. Cyclus engages with potential module developers and encourages them to join a vibrant community in an expanding ecosystem. Users and developers are always welcome and encouraged to use or contribute to the Cyclus project.},
-	journal = {Figshare},
+	publisher = {The Cyclus Project},
 	author = {Anderson, Aaron and Bachmann, Amanda and Bae, Jin Whan and Bhosale, Aditya and Bormann, Lewin and Caldwell-Overdier, Anna and Chandan, Snehal and Chee, Gwendolyn and Flanagan, Robert and Hodge, Ryan and Huff, Kathryn and Kleimenhagen, Kip and Krueger, Dean and McGarry, Meghan and Mouginot, Baptiste and Mummah, Kathryn and Nibbelink, Ben and Park, Gyutae and Redfoot, Emma and Robert, Yves and Schalz, Max and Scopatz, Anthony and Stomps, Jordan and Wang, Di and Wilson, Paul},
 	month = may,
 	year = {2024},
@@ -4159,7 +4162,7 @@ The goal of Cyclus is to enable a broad spectrum of fuel cycle simulation while 
 	author = {Turkmen, Mehmet and Chee, Gwendolyn J. Y. and Huff, Kathryn D.},
 	month = oct,
 	year = {2021},
-	keywords = {Optimization, Molten salt reactor, Monte Carlo, Simulation, Machine learning, Channel design},
+	keywords = {Optimization, Molten salt reactor, Monte Carlo, Simulation, Machine learning, Channel design, Include File on Website},
 	pages = {108409},
 }
 
@@ -4176,7 +4179,7 @@ The goal of Cyclus is to enable a broad spectrum of fuel cycle simulation while 
 	author = {Chaube, Anshuman and Chapman, Andrew and Minami, Akari and Stubbins, James and Huff, Kathryn D.},
 	month = dec,
 	year = {2021},
-	keywords = {Nuclear power, Energy model, Japan, Carbon capture, Hydrogen fuel cell},
+	keywords = {Nuclear power, Energy model, Japan, Carbon capture, Hydrogen fuel cell, Include File on Website},
 	pages = {117669},
 }
 
@@ -4194,7 +4197,7 @@ The goal of Cyclus is to enable a broad spectrum of fuel cycle simulation while 
 	author = {Chapman, Andrew and Shigetomi, Yosuke and Chandra Karmaker, Shamal and Baran Saha, Bidyut and Huff, Kathryn and Brooks, Caleb and Stubbins, James},
 	month = oct,
 	year = {2021},
-	keywords = {Energy justice, Energy policy, Culture, Demographics, Energy affordability, Recognition},
+	keywords = {Energy justice, Energy policy, Culture, Demographics, Energy affordability, Recognition, Include File on Website},
 	pages = {102231},
 }
 
@@ -4291,6 +4294,7 @@ S. 4280, to require the Secretary of Energy to remove carbon dioxide directly fr
 	month = mar,
 	year = {2023},
 	doi = {10.5772/intechopen.110144},
+	keywords = {Include File on Website},
 }
 
 @article{thiolliere_impact_2022,
@@ -4306,7 +4310,7 @@ S. 4280, to require the Secretary of Energy to remove carbon dioxide directly fr
 	author = {Thiollière, N. and Doligez, X. and Halasz, M. and Krivtchik, G. and Merino, I. and Mouginot, B. and Skarbeli, A. V. and Hernandez-Solis, A. and Alvarez-Velarde, F. and Courtin, F. and Druenne, H. and Ernoult, M. and Huff, K. and Szieberth, M. and Vermeeren, B. and Wilson, P.},
 	month = jun,
 	year = {2022},
-	keywords = {FIT project, Fuel Cycle Simulators, Fuel Loading Models, Pressurized Water Reactors, Sodium Fast Reactors},
+	keywords = {FIT project, Fuel Cycle Simulators, Fuel Loading Models, Pressurized Water Reactors, Sodium Fast Reactors, Include File on Website},
 	pages = {111748},
 }
 
@@ -4355,7 +4359,6 @@ S. 4280, to require the Secretary of Energy to remove carbon dioxide directly fr
 	note = {Publisher: figshare},
 }
 
-
 @misc{bachmann_fuel_2023,
 	address = {University of Tennessee, Knoxville},
 	title = {Fuel cycle needs of deploying advanced reactors},
@@ -4367,7 +4370,7 @@ S. 4280, to require the Secretary of Energy to remove carbon dioxide directly fr
 }
 
 @phdthesis{bachmann_investigation_2023,
-	type = {Thesis},
+	type = {Doctoral {Dissertation}},
 	title = {Investigation of the impacts of deploying reactors fueled by high-assay low enriched uranium},
 	copyright = {Copyright by Amanda M. Bachmann. All rights reserved.},
 	url = {https://hdl.handle.net/2142/121987},
@@ -4393,28 +4396,28 @@ The work completed in this dissertation develops and demonstrates a methodology 
 	title = {Preliminary {Results} of {Material} {Flow} {Controlled} {MSR} {Depletion} {Calculations}},
 	volume = {116},
 	url = {https://www.osti.gov/biblio/23050345},
-	abstract = {A versatile, parallelizable Python 2.7 library was developed in order to simulate once-through molten salt reactor depletion in a realistic manner via the coupled neutronics/depletion code Serpent 2. Realistic in this sense entails two aspects: reactivity of the core, and oxidation potential of the fuel. The core reactivity should be maintained near zero as with any nuclear reactor. Gross reactivity control is provided by variations of the refuel rate of the reactor. Fine reactivity adjustments are expected to be done with control mechanisms in real-life power operation. The Python library developed allows a user to set bounds on the desired ke f f value. Fuel oxidation potential must be controlled for any liquid fueled reactor. As a simple example, consider this fission where the fuel becomes more oxidizing: UF_4 → SrF_2 + Xe + 2F^- It can be shown using expected fission product oxidation state data that for these reactors, the fuel will become more oxidizing over time as a result of accumulation of excess fluoride ion. Addition of a reducing agent to reactor fuel will be necessary in the operation of molten salt reactors.},
+	abstract = {A versatile, parallelizable Python 2.7 library was developed in order to simulate once-through molten salt reactor depletion in a realistic manner via the coupled neutronics/depletion code Serpent 2. Realistic in this sense entails two aspects: reactivity of the core, and oxidation potential of the fuel. The core reactivity should be maintained near zero as with any nuclear reactor. Gross reactivity control is provided by variations of the refuel rate of the reactor. Fine reactivity adjustments are expected to be done with control mechanisms in real-life power operation. The Python library developed allows a user to set bounds on the desired ke f f value. Fuel oxidation potential must be controlled for any liquid fueled reactor. As a simple example, consider this fission where the fuel becomes more oxidizing: UF\_4 → SrF\_2 + Xe + 2F{\textasciicircum}- It can be shown using expected fission product oxidation state data that for these reactors, the fuel will become more oxidizing over time as a result of accumulation of excess fluoride ion. Addition of a reducing agent to reactor fuel will be necessary in the operation of molten salt reactors.},
 	language = {English},
 	urldate = {2024-06-03},
 	booktitle = {Transactions of the {American} {Nuclear} {Society}},
 	author = {Ridley, Gavin and Chvala, Ondrej},
 	month = jul,
 	year = {2017},
+	keywords = {out of group},
 }
 
 @mastersthesis{seifert_analysis_2023,
-	type = {Masters Thesis},
 	title = {Analysis of and comparison between reprocessing methods in the molten salt breeder reactor},
 	copyright = {Copyright 2023 Luke Seifert},
 	url = {https://hdl.handle.net/2142/122029},
-	abstract = {Liquid fueled molten salt reactor modeling can be challenging, as the fuel composition varies temporally and spatially. Although these models are challenging, they are important for predicting reactor safety and performance during operation. One of the reasons these models are challenging is the difficulty in capturing different physical phenomena which occur in different time scales. Over short time scales, one of these physical phenomena is the movement of delayed neutron precursors to less important regions of the reactor. For longer time scales, one of these physical phenomena is online reprocessing, which includes adding fresh fuel and removing fission products from the reactor during operation and is the focus of this work. Reprocessing is useful in liquid fueled molten salt reactors because it limits chemical corrosion and improves the neutron economy. Reprocessing can be performed continuously during operation, referred to as online reprocessing, or in batches during outages, referred to as batchwise reprocessing. In order to simulate reprocessing computationally, there are two different mathematical approaches which are commonly implemented in the literature, called batchwise and continuous reprocessing. The continuous reprocessing method is more physically reflective of reactors using a chemically continuous reprocessing scheme. However, there are many works which have implemented batchwise reprocessing methods to simulate a physically continuous reprocessing process. In this thesis, I show that continuous reprocessing and batchwise reprocessing methods are not interchangeable. Using both methods on the same system shows that there are non-trivial differences in the results. I also investigate the computational cost of different reprocessing methods by performing a depletion time step refinement study. In this study, I found that continuous reprocessing allows for significantly larger time steps without large increases in error, which reduces computational cost. However, continuous reprocessing does not necessarily keep the overall mass constant, thus potentially leading to a nonphysical solution. I compare the differences between both methods while determining the effect of this nonphysical mass change caused by continuous reprocessing.},
+	abstract = {Liquid fueled molten salt reactor modeling can be challenging, as the fuel composition varies temporally and spatially. Although these models are challenging, they are important for predicting reactor safety and performance during operation. One of the reasons these models are challenging is the difficulty in capturing different physical phenomena which occur in different time scales. Over short time scales, one of these physical phenomena is the movement of delayed neutron precursors to less important regions of the reactor.
+For longer time scales, one of these physical phenomena is online reprocessing, which includes adding fresh fuel and removing fission products from the reactor during operation and is the focus of this work. Reprocessing is useful in liquid fueled molten salt reactors because it limits chemical corrosion and improves the neutron economy. Reprocessing can be performed continuously during operation, referred to as online reprocessing, or in batches during outages, referred to as batchwise reprocessing. In order to simulate reprocessing computationally, there are two different mathematical approaches which are commonly implemented in the literature, called batchwise and continuous reprocessing. The continuous reprocessing method is more physically reflective of reactors using a chemically continuous reprocessing scheme. However, there are many works which have implemented batchwise reprocessing methods to simulate a physically continuous reprocessing process. In this thesis, I show that continuous reprocessing and batchwise reprocessing methods are not interchangeable. Using both methods on the same system shows that there are non-trivial differences in the results. I also investigate the computational cost of different reprocessing methods by performing a depletion time step refinement study. In this study, I found that continuous reprocessing allows for significantly larger time steps without large increases in error, which reduces computational cost. However, continuous reprocessing does not necessarily keep the overall mass constant, thus potentially leading to a nonphysical solution. I compare the differences between both methods while determining the effect of this nonphysical mass change caused by continuous reprocessing.},
 	urldate = {2024-06-03},
 	school = {University of Illinois at Urbana-Champaign},
 	author = {Seifert, Luke},
 	month = dec,
 	year = {2023},
 }
-
 
 @article{the_yt_project_introducing_2021,
 	title = {Introducing yt 4.0: {Analysis} and {Visualization} of {Volumetric} {Data}},
@@ -4423,14 +4426,14 @@ The work completed in this dissertation develops and demonstrates a methodology 
 	abstract = {We present the current version of the yt software package. yt is an open-source, communitydeveloped platform for analysis of volumetric data, with readers for several dozen data formats, indexing systems for gridded data, adaptive mesh re nement data, unstructured mesh data, discrete and particle formats, and octree-based data, as well as the combination of these. We describe the systems implemented in yt to facilitate a “science- rst” approach to data analysis, wherein the emphasis is on the meaning and interpretation of the data as opposed to its discretization or layout.},
 	language = {en-US},
 	urldate = {2024-06-04},
+	journal = {Manubot},
 	author = {{The YT Project} and Turk, Matthew and Goldbaum, Nathan J. and ZuHone, John A. and Hummels, Cameron and Ji, Suoqing and Lang, Meagan and Munk, Madicken and Smith, Britton and Kowalik, Kacper and Val-Borro, Miguel de and Coughlin, Jared W. and Cadiou, Corentin and Zingale, Michael and Orf, Leigh and Halbert, Kelton and Robert, Clément and Havlin, Christopher and Tonnesen, Stephanie and Myers, Andrew and Gurvich, Alex and Narayanan, Desika and Skillman, Samuel W. and Huebl, Axel and Biondo, Elliott and Wetzel, Andrew and Strawn, Clayton and Lindsay, Alexander and Altay, Gabriel and Lau, Erwin T. and Smith, Aaron and Kim, Ji-hoon and Schive, Hsi-Yu and S, Navaneeth and O'Shea, Brian W. and Abel, Tom and Gondhalekar, Yash and Gray, William J. and Gnedin, Nickolay Y. and Joana, Cristian and Li, Yuan and Farber, Ryan Jeffrey and Miller, Jonah M. and Ryan, Michael and Silvia, Devin W. and Jackson, Robert and Arraki, Kenz and Dutta, Alankar and Ghosh, Ritali and Xie, Shaokun and Naiman, Jill P. and Hix, Ronan and Borrow, Josh and Dong, Bili and Streicher, Ole and Mumford, Stuart and Keller, Benjamin and Thompson, Benjamin and Grete, Philipp and Wise, John H. and Tsai, Shin-Rong and Wijers, Nastasha Anna and Yourself, Add},
 	year = {2021},
-	note = {Publication Title: Manubot},
+	keywords = {Include File on Website},
 }
 
-
 @phdthesis{agosta_enhanced_2023,
-	type = {Thesis},
+	type = {Doctoral {Dissertation}},
 	title = {Enhanced method for the support of experiment safety analysis},
 	copyright = {2023 Roberto E. Fairhurst Agosta},
 	url = {https://hdl.handle.net/2142/122024},
@@ -4488,4 +4491,278 @@ Issue: 1},
 	year = {2017},
 }
 
+@techreport{richter_modeling_2023-1,
+	address = {Oak Ridge, TN},
+	type = {Technical {Report}},
+	title = {{MODELING} {AND} {SIMULATION} {OF} {AN} {XE}-100 {TYPE} {PEBBLE} {BED} {GAS}-{COOLED} {REACTOR} {WITH} {SCALE}},
+	url = {https://info.ornl.gov/sites/publications/Files/Pub196359.pdf},
+	number = {ORNL/TM-2023/2959},
+	institution = {Oak Ridge National Lab},
+	author = {Richter, Zoë and Davidson, Eva and Skutnik, Steve and Munk, Madicken},
+	month = aug,
+	year = {2023},
+}
 
+@article{bachmann_open-source_2024,
+	title = {An {Open}-{Source} {Coupling} for {Depletion} {During} {Fuel} {Cycle} {Modeling}},
+	volume = {0},
+	issn = {0029-5639},
+	url = {https://doi.org/10.1080/00295639.2024.2393940},
+	doi = {10.1080/00295639.2024.2393940},
+	abstract = {Fuel depletion is an important aspect of fuel cycle modeling, allowing a user to account for how loaded fuel compositions affect in-core and spent fuel compositions and their related fuel cycle metrics. Therefore, multiple methods have been developed to account for depletion within fuel cycle simulations. This work adds to that list of methods by introducing an open-source coupling between Cyclus and OpenMC to perform fuel depletion during a fuel cycle simulation, called OpenMCyclus. This work explains the methodology of OpenMCyclus and presents a benchmark comparison between the performance of OpenMCyclus and another Cyclus archetype that uses recipes to define spent fuel compositions. The development of this coupling expands the functionalities possible through Cyclus by providing real-time fuel depletion that is reactor agnostic and open source.},
+	number = {0},
+	urldate = {2024-09-12},
+	journal = {Nuclear Science and Engineering},
+	author = {Bachmann, Amanda M. and Yardas, Oleksandr and Munk, Madicken},
+	month = sep,
+	year = {2024},
+	note = {Publisher: Taylor \& Francis
+\_eprint: https://doi.org/10.1080/00295639.2024.2393940},
+	pages = {1--14},
+}
+
+@article{kennedy_national_2024,
+	title = {National {Council} on {Radiation} {Protection} ({NCRP}) 2024 annual meeting:advanced and small modular nuclear power reactors},
+	volume = {44},
+	issn = {1361-6498},
+	shorttitle = {National {Council} on {Radiation} {Protection} ({NCRP}) 2024 annual meeting},
+	doi = {10.1088/1361-6498/ad7ec4},
+	abstract = {On 25-26 March 2023, the U.S. National Council on Radiation Protection and Measurements (NCRP) held its 2024 annual meeting in Bethesda, Maryland, USA. The NCRP dates from 1929, and this meeting celebrated the 60th anniversary of receiving a U.S. Congressional Charter. For this annual meeting the NCRP felt it was essential to provide a briefing about advanced and small modular nuclear reactors (SMRs). The Journal of Radiological Protection is delighted to publish the following synopsis of material presented at the U.S. NCRP meeting. This synopsis is divided into five sections. The first section provides an overview of the whole meeting together with summaries of two context setting overview papers. The following four sessions of this synopsis are specific to advanced and small modular nuclear power reactors. The meeting also included keynote presentations by three of NCRP annual award recipients. The meeting topical areas were Technology Overview and Critical Issues. The individual papers laid the groundwork to understanding reactor technologies, terminology, and the fundamental concepts and processes for electrical generation. The perspectives of the U.S. Environmental Protection Agency and states, through the Conference of Radiation Control Program Directors were provided. The papers included a discussion of diverse topics including potential emergency preparedness considerations, radiological survey requirements, an evaluation of the future of nuclear power, the economics of reactors (both large and small), and the critical issues identified by the recent National Academies of Sciences' study on advanced reactors. The summary papers were developed to briefly document the major points and concepts presented during the oral papers presented at the 2024 NCRP Annual Meeting. The meeting heralded the dawn of a new era for commercial nuclear power.},
+	language = {eng},
+	number = {4},
+	journal = {Journal of Radiological Protection: Official Journal of the Society for Radiological Protection},
+	author = {Kennedy, William E. and Meserve, Richard A. and Higley, Kathryn A. and Huff, Kathryn D. and Hanson, Christopher T. and Ford, Michael and Schultheisz, Daniel and Smith, Todd and Kugelmass, Bret and Abou-Jaoude, Abdalla and Lovering, Jessica R. and Semancik, Jeffery D. and Cullen, Gregory V. and Cheatham, Jesse and Peterson, Per F. and Redmond Ii, Everett and Mirsky, Steven M. and Mahowald, Matt and Houts, Michael G. and Perkins, David and Vaghetto, Rodolfo and Duhig, John and VanHorne-Sealy, Col Jama D.},
+	month = oct,
+	year = {2024},
+	pmid = {39363610},
+	keywords = {nuclear, United States, Humans, Nuclear Reactors, advanced, annual, Congresses as Topic, meeting, modular, National Council on Radiation Protection, Radiation Protection},
+}
+
+@article{dotson_osier_2024,
+	title = {Osier: {A} {Python} package for multi-objective energy system optimization},
+	volume = {9},
+	issn = {2475-9066},
+	shorttitle = {Osier},
+	url = {https://joss.theoj.org/papers/10.21105/joss.06919},
+	doi = {10.21105/joss.06919},
+	abstract = {Transitioning to a clean energy economy will require expanded energy infrastructure. An
+equitable, or just, transition further requires the recognition of the people and communities
+directly affected by this transition. However, public preferences may be ignored during decision making processes related to energy infrastructure due to a lack of technical rigor or expertise
+(Johnson et al., 2021). This challenge is further complicated by the fact that people have
+and express preferences over many dimensions simultaneously. Multi-objective optimization
+offers a method to help decision makers and stakeholders understand the problem and analyze
+tradeoffs among solutions (Liebman, 1976). Although, to date, no open-source multi-objective
+energy modeling frameworks exist. Open-source multi-objective energy system framework
+(osier) is a Python package for designing and optimizing energy systems across an arbitrary
+number of dimensions. osier was designed to help localized communities articulate their
+energy preferences in a technical manner without requiring extensive technical expertise. In
+order to facilitate more robust tradeoff analysis, osier generates a set of solutions, called a
+Pareto front, that are composed of a number of technology portfolios. The Pareto front is
+calculated using multi-objective optimization using evolutionary algorithms. osier also extends
+the common modeling-to-generate-alternatives (MGA) algorithm into N-dimensional objective
+space, as opposed to the conventional single-objective MGA. This allows users to investigate
+the near-optimal space for appealing alternative solutions. In this way, osier may aid modelers
+in addressing procedural and recognition justice.},
+	language = {en},
+	number = {104},
+	urldate = {2024-12-06},
+	journal = {Journal of Open Source Software},
+	author = {Dotson, Samuel G. and Munk, Madicken},
+	month = dec,
+	year = {2024},
+	pages = {6919},
+}
+
+@inproceedings{seifert_analysis_2023-1,
+	address = {Niagara Falls, Ontario, Canada},
+	title = {An {Analysis} of {Error} {Associated} with {Reprocessing} {Methods} in {Molten} {Salt} {Reactors}},
+	author = {Seifert, Luke and Munk, Madicken},
+	month = aug,
+	year = {2023},
+}
+
+@article{conover_tech_2024,
+	title = {Tech companies want small nuclear reactors. {Here}’s how they’d work},
+	volume = {206},
+	url = {https://www.sciencenews.org/article/small-modular-nuclear-reactors-amazon},
+	abstract = {To fuel AI’s insatiable energy appetite, tech companies are going big on small nuclear reactors.},
+	language = {en-US},
+	number = {8},
+	urldate = {2024-12-21},
+	journal = {ScienceNews},
+	author = {Conover, Emily},
+	month = oct,
+	year = {2024},
+	note = {Section: Tech},
+}
+
+@inproceedings{park_hybrid_2025,
+	address = {Denver, CO},
+	title = {A {Hybrid} {SN}-{Diffusion} {Method} for {Molten} {Salt} {Reactor} {Control} {Rod} {Modeling}},
+	url = {https://www.ans.org/pubs/proceedings/article-58077/},
+	doi = {doi.org/10.13182/MC25-47048},
+	booktitle = {Proceedings of {The} {International} {Conference} on {Mathematics} and {Computational} {Methods} {Applied} to {Nuclear} {Science} and {Engineering} ({M}\&{C} 2025)},
+	publisher = {American Nuclear Society},
+	author = {Park, Sun Myung and Huff, Kathryn D and Munk, Madicken},
+	month = apr,
+	year = {2025},
+	pages = {430--439},
+}
+
+@misc{glaser_arfc_nodate,
+	title = {{ARFC} {GROUP} {POSTER} 2025},
+	url = {https://github.com/arfc/2025-group-poster/tree/main},
+	collaborator = {Glaser, Nathan and Richter, Zoë and Ryan, Nathan},
+}
+
+@article{bachmann_effects_2025,
+	title = {Effects of uranium impurities in downblended {HEU} on {HTGR} performance},
+	journal = {Nuclear Science and Engineering (submitted)},
+	author = {Bachmann, Amanda M. and Richter, Zoe and Huff, Kathryn and Munk, Madicken},
+	month = feb,
+	year = {2025},
+}
+
+@inproceedings{yardas_useful_2022,
+	address = {Urbana, IL},
+	title = {Useful {Practices} in {Open}-source software development for nucelar science and engineering},
+	url = {https://github.com/arfc/2022-yardas-student-conference},
+	booktitle = {Transactions of the {American} {Nuclear} {Society} {Student} {Conference}},
+	publisher = {American Nuclear Society},
+	author = {Yardas, Oleksandr},
+	month = apr,
+	year = {2022},
+}
+
+@inproceedings{seifert_luke_computationally_2025,
+	address = {Denver, Colorado},
+	title = {A {Computationally} {Tractable} {Model} for {Spatially} {Resolved} {Nuclide} {Concentrations} in {Flowing} {Fuel} {Molten} {Salt} {Reactors}},
+	url = {https://www.ans.org/pubs/proceedings/article-58045/},
+	doi = {10.13182/MC25-47141},
+	abstract = {Depletion simulations of flowing fuel molten salt reactors commonly do not distinguish between in-core and ex-core regions.
+Instead, they either irradiate the entire primary loop while scaling the flux, or irradiate the in-core volume alone, which leaves some amount of fuel salt out of the simulation.
+Either approximation results in some level of inaccuracy in nuclide concentrations.
+Various methods account for the flow of fuel salt between spatial regions, but a major hurdle is the computational cost.
+This work investigates a spatially resolved method to account for the impact flow and chemical removal has on concentrations of nuclides rapidly and accurately.
+Comparisons are made in this work between a spatially resolved method, spatially unresolved scaled flux method, other work from the literature, and experimental data.
+These comparisons show that the scaled flux method is sufficient for modeling most nuclides unless there is a large spatially dependent loss term, such as a large ex-core removal rate.
+In such a case, a spatially resolved method is needed.},
+	booktitle = {Proceedings of {The} {International} {Conference} on {Mathematics} and {Computational} {Methods} {Applied} to {Nuclear} {Science} and {Engineering} ({M}\&{C} 2025)},
+	publisher = {American Nuclear Society},
+	author = {{Seifert, Luke} and {Shahbazi, Shayan} and {Richards, Scott} and {Munk, Madicken} and {Huff, Kathryn}},
+	month = apr,
+	year = {2025},
+	pages = {92--101},
+}
+
+@article{seifert_delayed_2025,
+	title = {Delayed {Neutron} {Precursor} {Group} {Parameter} and {Spectra} {Generation} from {Fast} {Fission} of {235U} in {SCALE}},
+	doi = {https://doi.org/10.1080/00295639.2025.2525754},
+	journal = {Nuclear Science and Engineering},
+	author = {Seifert, Luke and Betzler, Benjamin and Wieselquist, William and Jessee, Matthew and Munk, Madicken and Huff, Kathryn D.},
+	year = {2025},
+	pages = {1--16},
+}
+
+@article{rochas_plans_2025,
+	chapter = {Energy},
+	title = {Plans to restart construction of {VC} {Summer} reactors gain traction},
+	url = {https://www.reuters.com/business/energy/plans-restart-construction-vc-summer-reactors-gain-traction-2025-07-04/},
+	abstract = {Due to their advanced stage of construction and the large components onsite, South Carolina's VC Summer 2 and 3 are in prime position to become the next large nuclear reactors built in the United States.},
+	language = {en-US},
+	urldate = {2025-07-15},
+	journal = {Reuters},
+	author = {Rochas, Anna Flávia and Rochas, Anna Flávia},
+	month = jul,
+	year = {2025},
+}
+
+@inproceedings{yardas_extension_2025,
+	address = {Tacoma, WA},
+	title = {Extension of the {OpenMC} depletion module for transport-independent depletion.},
+	doi = {https://doi.org/10.25080/ngdf5738},
+	abstract = {We have added functionality for running depletion simulations independently of neutron transport in OpenMC, an open source Monte Carlo particle transport code with an internal depletion module. Transport-independent depletion uses pre-computed static multigroup cross sections and fluxes to calculate reaction rates for OpenMC’s depletion matrix solver. This accelerates the depletion calculation, but removes the spatial coupling between depletion and neutron transport.
+
+We used a simple PWR pincell to validate the method against the existing transport-coupled depletion method. Nuclide concentration errors roughly scale with depletion time step size and are inversely proportional to the amount of the nuclide present in a depletable material. The magnitude of concentration error depends on the nuclide of interest. Concentration errors for low-abundance nuclides at longer (30-day) time steps exhibit large negative initial concentration the becomes more positive with time due to overestimation of nuclide production stemming from the lack of spatial coupling to neutron transport. For ten 3-day time steps, fission product concentration errors are all under 3\%. Actinide concentration errors range from 10-15\% for Am and Cm, 5-7\% for Pu and Np, and 2\% and less for U. Surprisingly, the numbers are similar for 30-day time steps. These results demonstrate the potential of this new method with moderate accuracy and extraordinary time savings for low and medium fidelity simulations. Concentration error characterization on larger models remains an open area of interest.},
+	booktitle = {Proceedings of the 24th {Python} in {Science} {Conference}},
+	author = {Yardas, Oleksandr and Romano, Paul and Munk, Madicken and Huff, Kathryn},
+	month = jul,
+	year = {2025},
+}
+
+@article{huff_what_2024,
+	title = {What it will take to restart decommissioned {US} nuclear plants. {A} primer},
+	url = {https://thebulletin.org/2024/10/what-it-will-take-to-restart-decommissioned-us-nuclear-plants-a-primer/},
+	abstract = {Nuclear plant restarts at Palisades and Three Mile Island Unit 1 are a test case for the future of the US nuclear industry, a former assistant secretary for nuclear energy argues.},
+	language = {en-US},
+	urldate = {2025-09-12},
+	journal = {Bulletin of the Atomic Scientists},
+	author = {Huff, Kathryn and Ryan, Nathan},
+	month = oct,
+	year = {2024},
+}
+
+@article{huff_taking_2025,
+	series = {Editorial},
+	title = {Taking nuclear energy to the {Moon}},
+	volume = {389},
+	issn = {0036-8075},
+	url = {https://www.science.org/doi/10.1126/science.aeb6479},
+	doi = {10.1126/science.aeb6479},
+	number = {6763},
+	urldate = {2025-09-12},
+	journal = {Science},
+	author = {Huff, Kathryn},
+	month = aug,
+	year = {2025},
+	note = {Publisher: American Association for the Advancement of Science},
+	pages = {859--859},
+}
+
+@article{huff_killing_2025,
+	series = {Opinion},
+	title = {Killing a {Nuclear} {Watchdog}’s {Independence} {Threatens} {Disaster}},
+	url = {https://www.scientificamerican.com/article/killing-a-nuclear-watchdogs-independence-threatens-disaster/},
+	abstract = {A Trump administration plan would end the independence of the Nuclear Regulatory Commission, where similar oversight muzzling has led to nuclear disasters overseas},
+	language = {en},
+	urldate = {2025-09-12},
+	journal = {Scientific American},
+	author = {Huff, Katy and Wilson, Paul and Corradini, Michael},
+	month = mar,
+	year = {2025},
+}
+
+@inproceedings{fang_einstein_2025,
+	title = {{EINSTEIN}: enhanced integrated nuclear systems for transmutation and efficient isolation of nuclides},
+	volume = {13621},
+	shorttitle = {{EINSTEIN}},
+	url = {https://www.spiedigitallibrary.org/conference-proceedings-of-spie/13621/136210G/EINSTEIN--enhanced-integrated-nuclear-systems-for-transmutation-and-efficient/10.1117/12.3067982.full},
+	doi = {10.1117/12.3067982},
+	abstract = {Transmutation systems based on different drivers and targets (XDS facilities) have been proposed to reduce the radiotoxicity of used nuclear fuel (UNF). We are developing a Techno-Economic Analysis framework informed by a dynamic data library integrated with a large-scale system simulator for rapidly evaluating and comparing various transmutation technologies. We will conduct experimental campaigns to measure a prioritized list of quantities including key reactions and fission yields to fill the gaps in experimental data. Among the data of interest, we simulated the measurement of $^{\textrm{19}}$F(n,n’γ) reaction cross section with an HPGe detector and demonstrated it is feasible to obtain a \&lt;1\% uncertainty with a measurement time of 1 hour. Ultimately, we aim to provide a detailed assessment of viable technologies at all UNF transmutation stages and their associated cost basis to inform future commercial applications.},
+	urldate = {2025-10-21},
+	booktitle = {Hard {X}-{Ray}, {Gamma}-{Ray}, and {Neutron} {Detector} {Physics} {XXVII}},
+	publisher = {SPIE},
+	author = {Fang, Ming and Huff, Kathryn and Kozlowski, Tomasz and Stubbins, James F. and Vergari, Lorenzo and Fulvio, Angela Di},
+	month = sep,
+	year = {2025},
+	pages = {128--133},
+}
+
+@article{seifert_accuracy_2025,
+	title = {Accuracy of the {Scaled} {Flux} {Method} for {Spatially} {Resolved} {Nuclide} {Transmutation} in {Flowing}-{Fuel} {Molten} {Salt} {Reactors}},
+	volume = {0},
+	issn = {0029-5639},
+	url = {https://doi.org/10.1080/00295639.2025.2568258},
+	doi = {10.1080/00295639.2025.2568258},
+	abstract = {Depletion simulations of flowing-fuel molten salt reactors do not typically distinguish between the in-core and ex-core regions. Instead, they either irradiate the entire primary loop while scaling the flux, or irradiate the in-core volume alone, which leaves some amount of fuel salt out of the simulation. Either approximation results in some level of inaccuracy in the nuclide concentrations. The method of scaling the flux is more commonly used, but this approach assumes perfect mixing of the fuel salt in the primary loop. This work investigates a spatially resolved method to account for the impact that the flow and chemical removal have on the concentrations of nuclides rapidly and accurately. Specifically, the spatially resolved model uses one-dimensional advection, which assumes no mixing in the primary loop. This model is used to provide the most conservative possible comparison, as any amount of mixing would only move the result closer to the scaled flux method. Comparisons are made in this work between this spatially resolved model, a scaled flux model, other work from the literature, and experimental data. These comparisons show that the scaled flux method is sufficient for modeling most nuclides unless there is a large spatially dependent loss term, near-stationary flow rate, or artificial power oscillations with almost no mixing. In such cases, a spatially resolved method is necessary.},
+	number = {0},
+	urldate = {2025-11-06},
+	journal = {Nuclear Science and Engineering},
+	author = {Seifert, Luke and Shahbazi, Shayan and Richards, Scott and Munk, Madicken and Huff, Kathryn},
+	month = sep,
+	year = {2025},
+	note = {Publisher: Taylor \& Francis
+\_eprint: https://doi.org/10.1080/00295639.2025.2568258},
+	keywords = {Molten salt reactor, Molten Salt Reactor Experiment, depletion, chemical removal, flow rate},
+	pages = {1--13},
+}


### PR DESCRIPTION
## Summary of changes
Updates the group publication list for the website. 
Adds 10 papers and 5 proceedings visible to the website, and other changes in the group Zotero `group-pubs` collection.


## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Associated Issues and PRs

- Issue: #496 (An associated presentation whose other information was added to this )


## Associated Developers

- Dev: @yardasol @katyhuff 


## Checklist for Reviewers

Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the
Review Checklist before they begin their review.

## Immediate Questions
 - The 2025 paper for luke's work on Delayed Neutron Precursors got modified in zotero, and now has a lot less information (e.g. previously had abstract, a publisher, etc) Is this intentional, or should some of that information be put back?
 Previously:
```
-@article{seifert_delayed_2025,
-  title={Delayed Neutron Precursor Group Parameter and Spectra Generation from Fast Fission of 235U in SCALE},
-  author={Seifert, Luke and Betzler, Benjamin and Wieselquist, William and Jessee, Matthew and Munk, Madicken and Huff, Kathryn},
-  journal={Nuclear Science and Engineering},
-  pages={1--16},
-  abstract={Delayed neutron precursor (DNP) group data are important for modeling reactor dynamics. Although the data for individual DNPs have been developed over time, the DNP group data present in the Evaluated Nuclear Data Files (ENDF) have not been updated in the past 20 years. In this work, we use SCALE to recreate the Godiva experiment that was used to generate the original DNP group structure for fast fission of 235U. However, each DNP is modeled using up-to-date data, and the results are then converted into a newly updated group structure. This conversion uses an iterative linear least squares solver to minimize chi-squared. The approaches used in this work also enable energy spectrum generation and uncertainty tracking. The method used in this paper for fast 235U fission DNP group structure updating can be applied to different energies and fissile nuclides. Demonstration of the uncertainty tracking in reactor kinetics and dynamics simulations is shown using point reactor kinetics simulations. Results show that there are data discrepancies between the International Atomic Energy Agency database and data used in ORIGEN, which are currently being fixed. Results also show that the proposed method for group spectra generation performs well.},
-  year={2025},
-  publisher={Taylor \& Francis}
-}
```
 New:
```
@article{seifert_delayed_2025,
+       title = {Delayed {Neutron} {Precursor} {Group} {Parameter} and {Spectra} {Generation} from {Fast} {Fission} of {235U} in {SCALE}},
+       doi = {https://doi.org/10.1080/00295639.2025.2525754},
+       journal = {Nuclear Science and Engineering},
+       author = {Seifert, Luke and Betzler, Benjamin and Wieselquist, William and Jessee, Matthew and Munk, Madicken and Huff, Kathryn D.},
+       year = {2025},
+       pages = {1--16},
+}
```
 -  By default in zotero export the tag `type = {Masters Thesis}` isn't included; I re-added them manually since that was the style before, but is that what we want?
 - Is the website supposed to be a specific font? I just realized that on my local machine, when I run it, there's a unique font for body text but on the actual website it just uses Arial (see pictures at end*)
 - Was it intentional that the title for `richter_isotopic_2022` had formatting changed? It changed in the latest Zotero's export and I wanted to check before I kept or reverted it.
 From
`title = {{ISOTOPIC} {AND} {REACTOR} {PHYSICS} {CHARACTERIZATION} {OF} {A} {GAS}-{COOLED}, {PEBBLE}-{BED} {MICROREACTOR}},`
 To
`title = {Isotopic and reator physics characterization of a gas-cooled, pebble-bed microreactor},`
 - I assume that for all items with the new tag `'Include File on Website'` I should make sure those items have files on the website?
 - Some of the papers, between last update and now, on the Zotero had a tag called `annote` removed. Is this intentional? Most of them were disclosures like
```
-       annote = {This material is based upon work supported under an Integrated University Program Graduate
-Fellowship. Any opinions, findings, conclusions or recommendations expressed in this publication are
-those of the author(s) and do not necessarily reflect the views of the Department of Energy
-Office of Nuclear Energy.},
```
 - It might have just been a while and I forgot, but does the website have a `CONTRIBUTING` document and/or tests set up to reference here?
 - One of the new items (`richter_modeling_2023-1`) is a tech report, should this also be added to the reports page on the website?

*Picture of font disparity: Left is local build, right is published website
<img width="1762" height="536" alt="image" src="https://github.com/user-attachments/assets/f35d793e-783d-4296-9aec-3178e0f8655b" />

